### PR TITLE
equip-2: scratch-persist reactive PostToolUse hook (generalized)

### DIFF
--- a/docs/lg.md
+++ b/docs/lg.md
@@ -4,7 +4,7 @@
 
 `lg` is a proactive wrapper for shell commands that may produce too much output for an agent turn. It captures combined stdout and stderr, writes the full transcript to a scratch file, and returns either the complete output or a bounded head-and-tail preview.
 
-This exists because a reactive `PostToolUse` hook cannot replace the standard tool response that already entered history. `lg` solves that earlier in the flow by wrapping the command before it runs.
+This exists because a reactive `PostToolUse` hook cannot replace the standard tool response that already entered history. `lg` solves that earlier in the flow by wrapping the command before it runs. Use [`scratch-persist`](scratch-persist.md) as the reactive safety net for verbose calls that were not wrapped proactively.
 
 ## Prerequisites
 

--- a/docs/scratch-persist.md
+++ b/docs/scratch-persist.md
@@ -1,0 +1,112 @@
+# scratch-persist
+
+## What/Why
+
+`scratch-persist` is the reactive half of context-kit's large-output handling. As a `PostToolUse` hook, it detects tool output at or above a character threshold, saves the complete tool input and output to a scratch Markdown file, and returns one `additionalContext` notice with the file path.
+
+A `PostToolUse` hook cannot replace the tool response that already entered conversation history. It is therefore a safety net, not a context-reduction mechanism for the current response. Use [`lg`](lg.md) proactively for shell commands likely to be verbose; `lg` returns bounded output, so this hook naturally stays below threshold for those calls.
+
+## Prerequisites
+
+- `python3 >= 3.9` must be available to Claude Code.
+- On macOS, if `python3` is missing because Command Line Tools are not installed yet, `xcode-select --install` is the usual first step.
+
+## Install
+
+1. Clone the repository.
+
+```sh
+git clone https://github.com/caty-ai/context-kit.git
+cd context-kit
+```
+
+2. Merge the hook into your existing Claude Code settings.
+
+Update either `~/.claude/settings.json` or `<project>/.claude/settings.json`. Merge this hook block into the existing file; do not overwrite unrelated settings.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/scratch-persist.sh\"; if [ -f \"$f\" ]; then bash \"$f\"; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+3. Reload hooks.
+
+Restart Claude Code or run `/hooks` so the new wiring is picked up.
+
+## Wiring Notes
+
+The guarded command stays silent when `<CONTEXT_KIT_DIR>` has not been replaced or the checkout moves. `PostToolUse` exit codes do not block a completed tool call, but a bare broken path would print an error after every tool call. The file guard avoids that repeated noise.
+
+The launcher resolves `scratch-persist.py` relative to its own location and fails open if the body or `python3` is unavailable. All controlled error paths exit `0` without stderr or malformed stdout. On success, stdout contains exactly one JSON object with `hookSpecificOutput.additionalContext`.
+
+Export hook environment variables from the shell, launcher, or app wrapper that starts Claude Code. Variables set only in a later interactive shell may not be visible to hooks.
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `CK_SCRATCH_DISABLED` | Set to `1` to disable reactive persistence. | unset |
+| `CK_SCRATCH_THRESHOLD` | Minimum extracted output length, in characters, that triggers persistence. Empty or non-numeric values fall back to the default. | `5000` |
+| `CK_SCRATCH_DIR` | Target directory for scratch files. Files are written directly into this directory. | `${HOME}/.claude/scratch/${CK_AGENT:-agent}/memory` when `HOME` is set; otherwise `${TMPDIR:-/tmp}/context-kit-scratch` |
+| `CK_AGENT` | Scratch subdirectory name when `CK_SCRATCH_DIR` is unset and `HOME` is available. | `agent` |
+
+## Scratch Behavior and Lifecycle
+
+The hook preserves the original response extraction surface: plain strings; `stdout`, `stderr`, `output`, `content`, and `result` dictionary fields; string list items; and list dictionaries containing `text` or `content` strings. Extracted parts retain that key order and are joined with newlines.
+
+Files use the `scratch-<timestamp>-<tool>.md` convention in the same directory as [`lg`](lg.md), with `mode: reactive-persist`, creation and expiration timestamps, and a 7-day TTL. A write is completed through an atomic same-directory replacement before the hook emits its notice. If directory creation, permission hardening, writing, syncing, or replacement fails, the hook emits no notice.
+
+Scratch files may contain secrets, tokens, stack traces, or raw customer data. The default scratch directory is created with mode `0700`. A user-supplied `CK_SCRATCH_DIR` keeps its existing permissions; protecting it is your responsibility.
+
+One cleanup job covers files produced by both reactive `scratch-persist` and proactive `lg`:
+
+```sh
+if [ -n "${CK_SCRATCH_DIR:-}" ]; then
+  scratch_dir="${CK_SCRATCH_DIR}"
+elif [ -n "${HOME:-}" ]; then
+  scratch_dir="${HOME}/.claude/scratch/${CK_AGENT:-agent}/memory"
+else
+  scratch_dir="${TMPDIR:-/tmp}/context-kit-scratch"
+fi
+find "${scratch_dir}" -type f -name 'scratch-*.md' -mtime +7 -delete
+```
+
+## Verify
+
+Run the self-check from the repository root:
+
+```sh
+bash tests/test_scratch_persist.sh
+```
+
+Above-threshold one-liner: this must create one file and print one valid notice JSON object.
+
+```sh
+scratch_dir=$(mktemp -d); export CK_SCRATCH_DIR="$scratch_dir" CK_SCRATCH_THRESHOLD=100; notice=$(python3 -c 'import json; print(json.dumps({"tool_name":"Bash","tool_input":{"command":"demo"},"tool_response":{"stdout":"x" * 6000}}))' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/scratch-persist.sh"; if [ -f "$f" ]; then bash "$f"; fi'); printf '%s\n' "$notice" | python3 -m json.tool >/dev/null && find "$scratch_dir" -type f -name 'scratch-*.md'
+```
+
+Below-threshold one-liner: this must print nothing and exit `0`.
+
+```sh
+scratch_dir=$(mktemp -d); export CK_SCRATCH_DIR="$scratch_dir" CK_SCRATCH_THRESHOLD=5000; python3 -c 'import json; print(json.dumps({"tool_name":"Bash","tool_input":{"command":"demo"},"tool_response":{"stdout":"small"}}))' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/scratch-persist.sh"; if [ -f "$f" ]; then bash "$f"; fi'; echo $?
+```
+
+Optional syntax, AST, and JSON checks:
+
+```sh
+bash -n hooks/scratch-persist.sh tests/test_scratch_persist.sh
+python3 -B -c "import ast; ast.parse(open('hooks/scratch-persist.py').read())"
+python3 -m json.tool examples/settings.json >/dev/null
+```

--- a/docs/scratch-persist.md
+++ b/docs/scratch-persist.md
@@ -45,11 +45,13 @@ Update either `~/.claude/settings.json` or `<project>/.claude/settings.json`. Me
 
 Restart Claude Code or run `/hooks` so the new wiring is picked up.
 
+The example intentionally omits `matcher`, so the hook fires after every tool call. If you want to scope it, add a matcher such as `"matcher": "Bash|Read|Grep|WebFetch"` on the `PostToolUse` entry.
+
 ## Wiring Notes
 
 The guarded command stays silent when `<CONTEXT_KIT_DIR>` has not been replaced or the checkout moves. `PostToolUse` exit codes do not block a completed tool call, but a bare broken path would print an error after every tool call. The file guard avoids that repeated noise.
 
-The launcher resolves `scratch-persist.py` relative to its own location and fails open if the body or `python3` is unavailable. All controlled error paths exit `0` without stderr or malformed stdout. On success, stdout contains exactly one JSON object with `hookSpecificOutput.additionalContext`.
+The launcher resolves `scratch-persist.py` relative to its own location, follows symlinks when `readlink` is available, and fails open if the body or `python3` is unavailable. All controlled error paths exit `0` without stderr or malformed stdout. On success, stdout contains exactly one JSON object with `hookSpecificOutput.additionalContext`.
 
 Export hook environment variables from the shell, launcher, or app wrapper that starts Claude Code. Variables set only in a later interactive shell may not be visible to hooks.
 
@@ -62,11 +64,13 @@ Export hook environment variables from the shell, launcher, or app wrapper that 
 | `CK_SCRATCH_DIR` | Target directory for scratch files. Files are written directly into this directory. | `${HOME}/.claude/scratch/${CK_AGENT:-agent}/memory` when `HOME` is set; otherwise `${TMPDIR:-/tmp}/context-kit-scratch` |
 | `CK_AGENT` | Scratch subdirectory name when `CK_SCRATCH_DIR` is unset and `HOME` is available. | `agent` |
 
+`CK_SCRATCH_DIR_IS_DEFAULT` is launcher-internal state used to decide whether the hook should harden directory permissions. Do not set it manually.
+
 ## Scratch Behavior and Lifecycle
 
 The hook preserves the original response extraction surface: plain strings; `stdout`, `stderr`, `output`, `content`, and `result` dictionary fields; string list items; and list dictionaries containing `text` or `content` strings. Extracted parts retain that key order and are joined with newlines.
 
-Files use the `scratch-<timestamp>-<tool>.md` convention in the same directory as [`lg`](lg.md), with `mode: reactive-persist`, creation and expiration timestamps, and a 7-day TTL. A write is completed through an atomic same-directory replacement before the hook emits its notice. If directory creation, permission hardening, writing, syncing, or replacement fails, the hook emits no notice.
+Files use the `scratch-<timestamp>-<tool>.md` convention in the same directory as [`lg`](lg.md), with a capped tool slug, same-second collision avoidance that keeps files flat under the scratch directory, `mode: reactive-persist`, creation and expiration timestamps, and a 7-day TTL. A write is completed through an atomic same-directory replacement before the hook emits its notice. If directory creation, permission hardening, writing, syncing, or replacement fails, the hook emits no notice.
 
 Scratch files may contain secrets, tokens, stack traces, or raw customer data. The default scratch directory is created with mode `0700`. A user-supplied `CK_SCRATCH_DIR` keeps its existing permissions; protecting it is your responsibility.
 
@@ -80,7 +84,7 @@ elif [ -n "${HOME:-}" ]; then
 else
   scratch_dir="${TMPDIR:-/tmp}/context-kit-scratch"
 fi
-find "${scratch_dir}" -type f -name 'scratch-*.md' -mtime +7 -delete
+find "${scratch_dir}" \( -type f -name 'scratch-*.md' -o -type f -name '.scratch-persist-*' \) -mtime +7 -delete
 ```
 
 ## Verify

--- a/examples/settings.json
+++ b/examples/settings.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/scratch-persist.sh\"; if [ -f \"$f\" ]; then bash \"$f\"; fi'"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/scratch-persist.py
+++ b/hooks/scratch-persist.py
@@ -9,11 +9,13 @@ import os
 import re
 import sys
 import tempfile
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 
 DEFAULT_THRESHOLD = 5000
 TTL_DAYS = 7
+MAX_TOOL_SLUG_LEN = 32
+MAX_UNIQUE_PROBES = 1024
 
 
 def extract_output(resp: Any) -> str:
@@ -59,8 +61,31 @@ def resolve_scratch_dir() -> Tuple[str, bool]:
     configured = os.environ.get("CK_SCRATCH_DIR")
     if configured:
         launched_as_default = os.environ.get("CK_SCRATCH_DIR_IS_DEFAULT") == "1"
-        return configured, launched_as_default
-    return default_scratch_dir(), True
+        return os.path.abspath(configured), launched_as_default
+    return os.path.abspath(default_scratch_dir()), True
+
+
+def slugify_tool(tool: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", tool.lower()).strip("-")
+    return (slug[:MAX_TOOL_SLUG_LEN] or "tool").rstrip("-") or "tool"
+
+
+def reserve_scratch_file(
+    scratch_dir: str, ts: str, safe_tool: str
+) -> Tuple[Optional[str], Optional[int]]:
+    pid = os.getpid()
+    base = "scratch-{}-{}".format(ts, safe_tool)
+    for attempt in range(MAX_UNIQUE_PROBES):
+        suffix = "" if attempt == 0 else "-{}-{}".format(pid, attempt)
+        scratch_file = os.path.join(scratch_dir, "{}{}.md".format(base, suffix))
+        try:
+            fd = os.open(scratch_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            return scratch_file, fd
+        except FileExistsError:
+            continue
+        except OSError:
+            return None, None
+    return None, None
 
 
 def render_scratch(
@@ -95,10 +120,11 @@ def render_scratch(
     )
 
 
-def write_atomically(scratch_file: str, content: str) -> bool:
+def write_atomically(scratch_file: str, reserved_fd: int, content: str) -> bool:
     scratch_dir = os.path.dirname(scratch_file)
     temp_path = ""
     try:
+        os.close(reserved_fd)
         with tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
@@ -112,11 +138,19 @@ def write_atomically(scratch_file: str, content: str) -> bool:
             os.fsync(handle.fileno())
         os.replace(temp_path, scratch_file)
     except Exception:
+        try:
+            os.close(reserved_fd)
+        except OSError:
+            pass
         if temp_path:
             try:
                 os.unlink(temp_path)
             except OSError:
                 pass
+        try:
+            os.unlink(scratch_file)
+        except OSError:
+            pass
         return False
     return True
 
@@ -132,7 +166,7 @@ def run() -> int:
     data = json.loads(raw)
     if not isinstance(data, dict):
         return 0
-    if "tool_name" not in data or "tool_input" not in data or "tool_response" not in data:
+    if "tool_name" not in data or "tool_response" not in data:
         return 0
 
     tool = data.get("tool_name")
@@ -154,15 +188,17 @@ def run() -> int:
     expires = (now + datetime.timedelta(days=TTL_DAYS)).replace(
         microsecond=0
     ).isoformat()
-    safe_tool = re.sub(r"[^a-z0-9]+", "-", tool.lower()).strip("-") or "tool"
-    scratch_file = os.path.join(scratch_dir, "scratch-{}-{}.md".format(ts, safe_tool))
+    safe_tool = slugify_tool(tool)
+    scratch_file, reserved_fd = reserve_scratch_file(scratch_dir, ts, safe_tool)
+    if not scratch_file or reserved_fd is None:
+        return 0
 
     content = render_scratch(tool, tool_input, output, created, expires)
-    if not write_atomically(scratch_file, content):
+    if not write_atomically(scratch_file, reserved_fd, content):
         return 0
 
     notice = (
-        "[scratch-persist] Saved {} characters of {} output to scratch: {} — "
+        "[scratch-persist] Saved {} characters of {} output to scratch: {} -- "
         "use Read/Grep on this file instead of re-running the tool when the same "
         "information is needed (TTL 7 days)."
     ).format(len(output), tool, scratch_file)
@@ -174,7 +210,7 @@ def run() -> int:
                     "additionalContext": notice,
                 }
             },
-            ensure_ascii=False,
+            ensure_ascii=True,
         )
     )
     return 0

--- a/hooks/scratch-persist.py
+++ b/hooks/scratch-persist.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Persist large Claude Code PostToolUse responses without blocking hooks."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import re
+import sys
+import tempfile
+from typing import Any, List, Tuple
+
+
+DEFAULT_THRESHOLD = 5000
+TTL_DAYS = 7
+
+
+def extract_output(resp: Any) -> str:
+    """Extract output from the response shapes used by Claude Code tools."""
+    if resp is None:
+        return ""
+    if isinstance(resp, str):
+        return resp
+    if isinstance(resp, dict):
+        parts: List[str] = []
+        for key in ("stdout", "stderr", "output", "content", "result"):
+            val = resp.get(key)
+            if isinstance(val, str):
+                parts.append(val)
+            elif isinstance(val, list):
+                for item in val:
+                    if isinstance(item, str):
+                        parts.append(item)
+                    elif isinstance(item, dict):
+                        text = item.get("text") or item.get("content") or ""
+                        if isinstance(text, str):
+                            parts.append(text)
+        return "\n".join(part for part in parts if part)
+    return str(resp)
+
+
+def threshold_from_env() -> int:
+    try:
+        return int(os.environ.get("CK_SCRATCH_THRESHOLD", str(DEFAULT_THRESHOLD)))
+    except (TypeError, ValueError, OverflowError):
+        return DEFAULT_THRESHOLD
+
+
+def default_scratch_dir() -> str:
+    home = os.environ.get("HOME")
+    if home:
+        agent = os.environ.get("CK_AGENT") or "agent"
+        return os.path.join(home, ".claude", "scratch", agent, "memory")
+    return os.path.join(os.environ.get("TMPDIR") or "/tmp", "context-kit-scratch")
+
+
+def resolve_scratch_dir() -> Tuple[str, bool]:
+    configured = os.environ.get("CK_SCRATCH_DIR")
+    if configured:
+        launched_as_default = os.environ.get("CK_SCRATCH_DIR_IS_DEFAULT") == "1"
+        return configured, launched_as_default
+    return default_scratch_dir(), True
+
+
+def render_scratch(
+    tool: str,
+    tool_input: Any,
+    output: str,
+    created: str,
+    expires: str,
+) -> str:
+    try:
+        rendered_input = json.dumps(tool_input, ensure_ascii=False, indent=2)
+    except Exception:
+        rendered_input = str(tool_input)
+
+    return "".join(
+        (
+            "---\n",
+            "type: scratch\n",
+            "mode: reactive-persist\n",
+            "tool: {}\n".format(tool),
+            "createdAt: {}\n".format(created),
+            "expiresAt: {}\n".format(expires),
+            "sizeBytes: {}\n".format(len(output.encode("utf-8"))),
+            "---\n\n",
+            "## Tool Input\n\n",
+            "```json\n",
+            rendered_input,
+            "\n```\n\n",
+            "## Tool Output\n\n",
+            output,
+        )
+    )
+
+
+def write_atomically(scratch_file: str, content: str) -> bool:
+    scratch_dir = os.path.dirname(scratch_file)
+    temp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=scratch_dir,
+            prefix=".scratch-persist-",
+            delete=False,
+        ) as handle:
+            temp_path = handle.name
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, scratch_file)
+    except Exception:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+        return False
+    return True
+
+
+def run() -> int:
+    if os.environ.get("CK_SCRATCH_DISABLED") == "1":
+        return 0
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 0
+
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        return 0
+    if "tool_name" not in data or "tool_input" not in data or "tool_response" not in data:
+        return 0
+
+    tool = data.get("tool_name")
+    if not isinstance(tool, str) or not tool:
+        return 0
+    tool_input = data.get("tool_input") or {}
+    output = extract_output(data.get("tool_response"))
+    if len(output) < threshold_from_env():
+        return 0
+
+    scratch_dir, is_default = resolve_scratch_dir()
+    os.makedirs(scratch_dir, exist_ok=True)
+    if is_default:
+        os.chmod(scratch_dir, 0o700)
+
+    now = datetime.datetime.now()
+    ts = now.strftime("%Y-%m-%dT%H-%M-%S")
+    created = now.replace(microsecond=0).isoformat()
+    expires = (now + datetime.timedelta(days=TTL_DAYS)).replace(
+        microsecond=0
+    ).isoformat()
+    safe_tool = re.sub(r"[^a-z0-9]+", "-", tool.lower()).strip("-") or "tool"
+    scratch_file = os.path.join(scratch_dir, "scratch-{}-{}.md".format(ts, safe_tool))
+
+    content = render_scratch(tool, tool_input, output, created, expires)
+    if not write_atomically(scratch_file, content):
+        return 0
+
+    notice = (
+        "[scratch-persist] Saved {} characters of {} output to scratch: {} — "
+        "use Read/Grep on this file instead of re-running the tool when the same "
+        "information is needed (TTL 7 days)."
+    ).format(len(output), tool, scratch_file)
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": notice,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+def main() -> int:
+    try:
+        return run()
+    except BaseException:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/scratch-persist.sh
+++ b/hooks/scratch-persist.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# scratch-persist - fail-open launcher for the reactive PostToolUse hook.
+
+set -u
+
+if [ "${CK_SCRATCH_DISABLED:-0}" = "1" ]; then
+  exit 0
+fi
+
+export CK_SCRATCH_THRESHOLD="${CK_SCRATCH_THRESHOLD:-5000}"
+
+if [ -n "${CK_SCRATCH_DIR:-}" ]; then
+  export CK_SCRATCH_DIR_IS_DEFAULT=0
+elif [ -n "${HOME:-}" ]; then
+  export CK_SCRATCH_DIR="${HOME}/.claude/scratch/${CK_AGENT:-agent}/memory"
+  export CK_SCRATCH_DIR_IS_DEFAULT=1
+else
+  export CK_SCRATCH_DIR="${TMPDIR:-/tmp}/context-kit-scratch"
+  export CK_SCRATCH_DIR_IS_DEFAULT=1
+fi
+
+BODY_DIR=$(dirname "$0" 2>/dev/null) || exit 0
+BODY="${BODY_DIR}/scratch-persist.py"
+if [ ! -f "${BODY}" ] || ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+python3 "${BODY}" 2>/dev/null || true
+exit 0

--- a/hooks/scratch-persist.sh
+++ b/hooks/scratch-persist.sh
@@ -19,7 +19,29 @@ else
   export CK_SCRATCH_DIR_IS_DEFAULT=1
 fi
 
-BODY_DIR=$(dirname "$0" 2>/dev/null) || exit 0
+SCRIPT_PATH=$0
+if command -v readlink >/dev/null 2>&1; then
+  LINK_COUNT=0
+  MAX_LINKS=40
+  while [ -L "${SCRIPT_PATH}" ]; do
+    if [ "${LINK_COUNT}" -ge "${MAX_LINKS}" ]; then
+      exit 0
+    fi
+    LINK_COUNT=$((LINK_COUNT + 1))
+    LINK_TARGET=$(readlink "${SCRIPT_PATH}" 2>/dev/null) || break
+    case "${LINK_TARGET}" in
+      /*)
+        SCRIPT_PATH="${LINK_TARGET}"
+        ;;
+      *)
+        SCRIPT_DIR=$(dirname "${SCRIPT_PATH}" 2>/dev/null) || break
+        SCRIPT_PATH="${SCRIPT_DIR}/${LINK_TARGET}"
+        ;;
+    esac
+  done
+fi
+
+BODY_DIR=$(cd "$(dirname "${SCRIPT_PATH}")" 2>/dev/null && pwd -P) || exit 0
 BODY="${BODY_DIR}/scratch-persist.py"
 if [ ! -f "${BODY}" ] || ! command -v python3 >/dev/null 2>&1; then
   exit 0

--- a/tests/test_scratch_persist.sh
+++ b/tests/test_scratch_persist.sh
@@ -80,7 +80,7 @@ PY
 }
 
 first_scratch_file() {
-  find "$1" -type f -name 'scratch-*.md' -print 2>/dev/null | head -n 1
+  find "$1" -type f -name 'scratch-*.md' -print 2>/dev/null | head -n 1 || true
 }
 
 dir_mode() {
@@ -176,16 +176,46 @@ case_invalid_inputs() {
     ''
     'garbage'
     '[]'
-    '{"tool_name":"Bash"}'
+    '{"tool_name":"Bash","tool_input":{"command":"demo"}}'
   )
   for payload in "${payloads[@]}"; do
     run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=1
     if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDOUT}" ] || [ -s "${RUN_STDERR}" ]; then
-      record_fail "${case_name}" "expected empty, garbage, non-dict, and missing-field input to fail silently"
+      record_fail "${case_name}" "expected empty, garbage, non-dict, and missing-tool_response input to fail silently"
       return
     fi
   done
   record_pass "${case_name}"
+}
+
+case_missing_tool_input_persists() {
+  local case_name="missing-tool-input-persists"
+  local scratch_dir="${TMP_DIR}/missing-tool-input"
+  local payload
+  local scratch_file
+  payload=$(python3 - <<'PY'
+import json
+
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_response": {"stdout": "Y" * 6000},
+}))
+PY
+)
+  run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=5000
+  scratch_file=$(first_scratch_file "${scratch_dir}")
+  if [ "${RUN_STATUS}" = "0" ] &&
+     [ ! -s "${RUN_STDERR}" ] &&
+     [ -n "${scratch_file}" ] &&
+     [ -f "${scratch_file}" ] &&
+     notice_is_valid_for_path "${RUN_STDOUT}" "${scratch_file}" &&
+     grep -Fq '## Tool Input' "${scratch_file}" &&
+     grep -Fq '{}' "${scratch_file}" &&
+     grep -Fq 'YYYY' "${scratch_file}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected missing tool_input to default to {} and still persist"
+  fi
 }
 
 case_extraction_shapes() {
@@ -290,27 +320,16 @@ case_invalid_threshold_defaults() {
 
 case_write_failure_no_notice() {
   local case_name="write-failure-no-notice"
-  local scratch_dir="${TMP_DIR}/replace-blocked"
+  local scratch_dir="${TMP_DIR}/write-blocked"
   local payload
-  mkdir -p "${scratch_dir}"
-  python3 - "${scratch_dir}" <<'PY'
-import datetime
-import pathlib
-import sys
-
-root = pathlib.Path(sys.argv[1])
-now = datetime.datetime.now()
-for offset in range(-2, 4):
-    ts = (now + datetime.timedelta(seconds=offset)).strftime("%Y-%m-%dT%H-%M-%S")
-    (root / "scratch-{}-bash.md".format(ts)).mkdir()
-PY
+  printf 'not-a-directory' > "${scratch_dir}"
   payload=$(payload_for plain 100)
   run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=1
   if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDOUT}" ] && [ ! -s "${RUN_STDERR}" ] &&
      [ -z "$(first_scratch_file "${scratch_dir}")" ]; then
     record_pass "${case_name}"
   else
-    record_fail "${case_name}" "expected failed atomic replacement to emit no notice or final file"
+    record_fail "${case_name}" "expected a non-directory scratch target to emit no notice or final file"
   fi
 }
 
@@ -398,10 +417,163 @@ case_home_unset_fallback() {
   fi
 }
 
+case_collision_gets_unique_files() {
+  local case_name="collision-gets-unique-files"
+  local scratch_dir="${TMP_DIR}/collision"
+  local result_file="${TMP_DIR}/collision-result.json"
+  if env PYTHONDONTWRITEBYTECODE=1 CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=1 HOOK_PATH="${ROOT}/hooks/scratch-persist.py" RESULT_PATH="${result_file}" \
+    python3 - <<'PY'
+import contextlib
+import datetime
+import importlib.util
+import io
+import json
+import os
+import sys
+
+hook_path = os.environ["HOOK_PATH"]
+result_path = os.environ["RESULT_PATH"]
+spec = importlib.util.spec_from_file_location("scratch_persist_hook", hook_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class FrozenDatetime(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        value = cls(2026, 8, 7, 12, 34, 56)
+        if tz is not None:
+            return tz.fromutc(value.replace(tzinfo=tz))
+        return value
+
+module.datetime.datetime = FrozenDatetime
+
+payloads = (
+    {
+        "tool_name": "Bash",
+        "tool_input": {"command": "first"},
+        "tool_response": {"stdout": "FIRST-CONTENT"},
+    },
+    {
+        "tool_name": "Bash",
+        "tool_input": {"command": "second"},
+        "tool_response": {"stdout": "SECOND-CONTENT"},
+    },
+)
+
+notices = []
+for payload in payloads:
+    stdout = io.StringIO()
+    stdin = io.StringIO(json.dumps(payload))
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(io.StringIO()):
+        original_stdin = sys.stdin
+        sys.stdin = stdin
+        try:
+            rc = module.run()
+        finally:
+            sys.stdin = original_stdin
+    notices.append({"rc": rc, "stdout": stdout.getvalue().strip()})
+
+files = sorted(
+    os.path.join(os.environ["CK_SCRATCH_DIR"], name)
+    for name in os.listdir(os.environ["CK_SCRATCH_DIR"])
+    if name.startswith("scratch-") and name.endswith(".md")
+)
+
+with open(result_path, "w", encoding="utf-8") as handle:
+    json.dump({"files": files, "notices": notices}, handle)
+PY
+  then
+    :
+  else
+    record_fail "${case_name}" "expected deterministic same-second runs to complete"
+    return
+  fi
+
+  if python3 - "${result_file}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+assert len(data["files"]) == 2
+assert len(set(data["files"])) == 2
+
+expected_markers = ("FIRST-CONTENT", "SECOND-CONTENT")
+seen_paths = set()
+for item, marker in zip(data["notices"], expected_markers):
+    assert item["rc"] == 0
+    payload = json.loads(item["stdout"])
+    notice = payload["hookSpecificOutput"]["additionalContext"]
+    matching_paths = [path for path in data["files"] if path in notice]
+    assert len(matching_paths) == 1
+    path = matching_paths[0]
+    assert path not in seen_paths
+    seen_paths.add(path)
+    with open(path, encoding="utf-8") as handle:
+        content = handle.read()
+    assert marker in content
+
+assert seen_paths == set(data["files"])
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected same-second same-tool runs to produce two distinct files and notices"
+  fi
+}
+
+case_tool_slug_capped() {
+  local case_name="tool-slug-capped"
+  local scratch_dir="${TMP_DIR}/slug-cap"
+  local long_name
+  local payload
+  local scratch_file
+  long_name=$(python3 - <<'PY'
+print("A" * 300)
+PY
+)
+  payload=$(python3 - "${long_name}" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "tool_name": sys.argv[1],
+    "tool_input": {"command": "slug-check"},
+    "tool_response": {"stdout": "Z" * 6000},
+}))
+PY
+)
+  run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=5000
+  scratch_file=$(first_scratch_file "${scratch_dir}")
+  if [ "${RUN_STATUS}" = "0" ] &&
+     [ ! -s "${RUN_STDERR}" ] &&
+     [ -n "${scratch_file}" ] &&
+     [ -f "${scratch_file}" ] &&
+     notice_is_valid_for_path "${RUN_STDOUT}" "${scratch_file}" &&
+     python3 - "${scratch_file}" <<'PY'
+import os
+import re
+import sys
+
+name = os.path.basename(sys.argv[1])
+match = re.fullmatch(r"scratch-[0-9T-]+-([a-z0-9-]+)\.md", name)
+assert match is not None
+assert len(match.group(1)) <= 32
+assert match.group(1) == "a" * 32
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected long tool names to persist with a 32-character slug"
+  fi
+}
+
 case_above_threshold
 case_below_threshold
 case_disabled
 case_invalid_inputs
+case_missing_tool_input_persists
 case_extraction_shapes
 case_threshold_override
 case_invalid_threshold_defaults
@@ -410,4 +582,6 @@ case_unwritable_dir_root_skip
 case_user_scratch_keeps_mode
 case_default_scratch_created_700
 case_home_unset_fallback
+case_collision_gets_unique_files
+case_tool_slug_capped
 finish

--- a/tests/test_scratch_persist.sh
+++ b/tests/test_scratch_persist.sh
@@ -318,8 +318,8 @@ case_invalid_threshold_defaults() {
   record_pass "${case_name}"
 }
 
-case_write_failure_no_notice() {
-  local case_name="write-failure-no-notice"
+case_invalid_scratch_target_silent() {
+  local case_name="invalid-scratch-target-silent"
   local scratch_dir="${TMP_DIR}/write-blocked"
   local payload
   printf 'not-a-directory' > "${scratch_dir}"
@@ -330,6 +330,66 @@ case_write_failure_no_notice() {
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "expected a non-directory scratch target to emit no notice or final file"
+  fi
+}
+
+case_write_failure_no_notice() {
+  local case_name="write-failure-no-notice"
+  local scratch_dir="${TMP_DIR}/replace-failure"
+  if env PYTHONDONTWRITEBYTECODE=1 CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=5000 HOOK_PATH="${ROOT}/hooks/scratch-persist.py" \
+    python3 - <<'PY'
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+
+hook_path = os.environ["HOOK_PATH"]
+spec = importlib.util.spec_from_file_location("scratch_persist_hook", hook_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+payload = {
+    "tool_name": "Bash",
+    "tool_input": {"command": "printf write-failure"},
+    "tool_response": {"stdout": "WRITE-FAILURE-CONTENT" + ("x" * 6000)},
+}
+stdout = io.StringIO()
+stderr = io.StringIO()
+original_stdin = sys.stdin
+original_replace = module.os.replace
+replace_calls = []
+
+def fail_replace(source, destination):
+    replace_calls.append((source, destination))
+    raise OSError("simulated os.replace failure")
+
+module.os.replace = fail_replace
+sys.stdin = io.StringIO(json.dumps(payload))
+try:
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        rc = module.run()
+finally:
+    sys.stdin = original_stdin
+    module.os.replace = original_replace
+
+scratch_dir = os.environ["CK_SCRATCH_DIR"]
+names = os.listdir(scratch_dir)
+scratch_files = [name for name in names if name.startswith("scratch-") and name.endswith(".md")]
+temp_files = [name for name in names if name.startswith(".scratch-persist-")]
+
+assert rc == 0
+assert replace_calls
+assert stdout.getvalue() == ""
+assert stderr.getvalue() == ""
+assert scratch_files == []
+assert temp_files == []
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected os.replace failure to clean reserved and temporary files without output"
   fi
 }
 
@@ -577,6 +637,7 @@ case_missing_tool_input_persists
 case_extraction_shapes
 case_threshold_override
 case_invalid_threshold_defaults
+case_invalid_scratch_target_silent
 case_write_failure_no_notice
 case_unwritable_dir_root_skip
 case_user_scratch_keeps_mode

--- a/tests/test_scratch_persist.sh
+++ b/tests/test_scratch_persist.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+HOOK="${ROOT}/hooks/scratch-persist.sh"
+TMP_DIR=$(mktemp -d)
+PASS_COUNT=0
+FAIL_COUNT=0
+RUN_STDOUT=""
+RUN_STDERR=""
+RUN_STATUS=0
+
+cleanup() {
+  chmod -R u+rwx "${TMP_DIR}" 2>/dev/null || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+record_pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+record_fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+finish() {
+  if [ "${FAIL_COUNT}" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+run_hook() {
+  local payload="$1"
+  shift
+  RUN_STDOUT="${TMP_DIR}/stdout.$RANDOM"
+  RUN_STDERR="${TMP_DIR}/stderr.$RANDOM"
+  if printf '%s' "${payload}" | env "$@" bash "${HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+}
+
+payload_for() {
+  local shape="$1"
+  local size="$2"
+  python3 - "${shape}" "${size}" <<'PY'
+import json
+import sys
+
+shape = sys.argv[1]
+size = int(sys.argv[2])
+text = "x" * size
+if shape == "plain":
+    response = "PLAIN-BEGIN" + text + "PLAIN-END"
+elif shape == "streams":
+    response = {"stdout": "STDOUT-BEGIN" + text, "stderr": "STDERR-END"}
+elif shape == "content":
+    response = {"content": [{"text": "CONTENT-TEXT" + text}, {"content": "CONTENT-FALLBACK"}]}
+elif shape == "mixed":
+    response = {
+        "stdout": "MIXED-STDOUT" + text,
+        "stderr": "MIXED-STDERR",
+        "output": "MIXED-OUTPUT",
+        "content": ["MIXED-LIST", {"text": "MIXED-TEXT"}],
+        "result": "MIXED-RESULT",
+    }
+else:
+    response = {"stdout": text}
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": "printf full-output"},
+    "tool_response": response,
+}))
+PY
+}
+
+first_scratch_file() {
+  find "$1" -type f -name 'scratch-*.md' -print 2>/dev/null | head -n 1
+}
+
+dir_mode() {
+  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
+notice_is_valid_for_path() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+notice = data["hookSpecificOutput"]["additionalContext"]
+assert data["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+assert sys.argv[2] in notice
+assert "Read/Grep" in notice
+assert "instead of re-running the tool" in notice
+assert "TTL 7 days" in notice
+PY
+}
+
+case_above_threshold() {
+  local case_name="above-threshold-persists-and-notices"
+  local scratch_dir="${TMP_DIR}/above"
+  local payload
+  local scratch_file
+  payload=$(payload_for plain 6000)
+  run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=5000
+  scratch_file=$(first_scratch_file "${scratch_dir}")
+  if [ "${RUN_STATUS}" = "0" ] &&
+     [ ! -s "${RUN_STDERR}" ] &&
+     [ -n "${scratch_file}" ] &&
+     [ -f "${scratch_file}" ] &&
+     [ "$(wc -l < "${RUN_STDOUT}" | tr -d ' ')" = "1" ] &&
+     notice_is_valid_for_path "${RUN_STDOUT}" "${scratch_file}" &&
+     grep -Fq 'type: scratch' "${scratch_file}" &&
+     grep -Fq 'mode: reactive-persist' "${scratch_file}" &&
+     grep -Fq 'tool: Bash' "${scratch_file}" &&
+     grep -Fq 'createdAt:' "${scratch_file}" &&
+     grep -Fq 'expiresAt:' "${scratch_file}" &&
+     grep -Fq 'sizeBytes:' "${scratch_file}" &&
+     grep -Fq 'printf full-output' "${scratch_file}" &&
+     grep -Fq 'PLAIN-BEGIN' "${scratch_file}" &&
+     grep -Fq 'PLAIN-END' "${scratch_file}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a complete scratch file and one valid path-bearing notice"
+  fi
+}
+
+case_below_threshold() {
+  local case_name="below-threshold-silent"
+  local scratch_dir="${TMP_DIR}/below"
+  local payload
+  payload=$(payload_for plain 20)
+  run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=5000
+  if [ "${RUN_STATUS}" = "0" ] &&
+     [ ! -s "${RUN_STDOUT}" ] &&
+     [ ! -s "${RUN_STDERR}" ] &&
+     [ -z "$(first_scratch_file "${scratch_dir}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected no file or output below threshold"
+  fi
+}
+
+case_disabled() {
+  local case_name="disabled-silent"
+  local scratch_dir="${TMP_DIR}/disabled"
+  local payload
+  payload=$(payload_for plain 100)
+  run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=1 CK_SCRATCH_DISABLED=1
+  if [ "${RUN_STATUS}" = "0" ] &&
+     [ ! -s "${RUN_STDOUT}" ] &&
+     [ ! -s "${RUN_STDERR}" ] &&
+     [ -z "$(first_scratch_file "${scratch_dir}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected CK_SCRATCH_DISABLED=1 to do nothing"
+  fi
+}
+
+case_invalid_inputs() {
+  local case_name="invalid-inputs-silent"
+  local scratch_dir="${TMP_DIR}/invalid"
+  local payload
+  local payloads=(
+    ''
+    'garbage'
+    '[]'
+    '{"tool_name":"Bash"}'
+  )
+  for payload in "${payloads[@]}"; do
+    run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=1
+    if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDOUT}" ] || [ -s "${RUN_STDERR}" ]; then
+      record_fail "${case_name}" "expected empty, garbage, non-dict, and missing-field input to fail silently"
+      return
+    fi
+  done
+  record_pass "${case_name}"
+}
+
+case_extraction_shapes() {
+  local case_name="extraction-shapes"
+  local shape
+  local scratch_dir
+  local scratch_file
+  local payload
+  for shape in plain streams content mixed; do
+    scratch_dir="${TMP_DIR}/shape-${shape}"
+    payload=$(payload_for "${shape}" 100)
+    run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=10
+    scratch_file=$(first_scratch_file "${scratch_dir}")
+    if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ] || [ -z "${scratch_file}" ]; then
+      record_fail "${case_name}" "expected ${shape} output to persist"
+      return
+    fi
+    case "${shape}" in
+      plain)
+        if ! grep -Fq 'PLAIN-BEGIN' "${scratch_file}" || ! grep -Fq 'PLAIN-END' "${scratch_file}"; then
+          record_fail "${case_name}" "plain string text was not captured"
+          return
+        fi
+        ;;
+      streams)
+        if ! grep -Fq 'STDOUT-BEGIN' "${scratch_file}" || ! grep -Fq 'STDERR-END' "${scratch_file}"; then
+          record_fail "${case_name}" "stdout and stderr text were not captured"
+          return
+        fi
+        ;;
+      content)
+        if ! grep -Fq 'CONTENT-TEXT' "${scratch_file}" || ! grep -Fq 'CONTENT-FALLBACK' "${scratch_file}"; then
+          record_fail "${case_name}" "content list dictionaries were not captured"
+          return
+        fi
+        ;;
+      mixed)
+        if ! python3 - "${scratch_file}" <<'PY'
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    output = handle.read().split("## Tool Output\n\n", 1)[1]
+expected = "\n".join((
+    "MIXED-STDOUT" + ("x" * 100),
+    "MIXED-STDERR",
+    "MIXED-OUTPUT",
+    "MIXED-LIST",
+    "MIXED-TEXT",
+    "MIXED-RESULT",
+))
+assert output == expected
+PY
+        then
+          record_fail "${case_name}" "all extraction keys and their original order must be preserved"
+          return
+        fi
+        ;;
+    esac
+  done
+  record_pass "${case_name}"
+}
+
+case_threshold_override() {
+  local case_name="threshold-override-100"
+  local scratch_dir="${TMP_DIR}/override"
+  local default_dir="${TMP_DIR}/override-default"
+  local payload
+  payload=$(payload_for plain 120)
+  run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=100
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ] || [ -z "$(first_scratch_file "${scratch_dir}")" ]; then
+    record_fail "${case_name}" "expected 120 characters to exceed the 100-character override"
+    return
+  fi
+  run_hook "${payload}" CK_SCRATCH_DIR="${default_dir}"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDOUT}" ] && [ ! -s "${RUN_STDERR}" ] &&
+     [ -z "$(first_scratch_file "${default_dir}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected the same output to stay below the default threshold"
+  fi
+}
+
+case_invalid_threshold_defaults() {
+  local case_name="invalid-threshold-defaults"
+  local scratch_dir
+  local payload
+  local threshold
+  local thresholds
+  payload=$(payload_for plain 200)
+  thresholds=(not-a-number "$(python3 -c 'print("9" * 5000)')")
+  for threshold in "${thresholds[@]}"; do
+    scratch_dir="${TMP_DIR}/invalid-threshold-${RANDOM}"
+    run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD="${threshold}"
+    if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDOUT}" ] || [ -s "${RUN_STDERR}" ] ||
+       [ -n "$(first_scratch_file "${scratch_dir}")" ]; then
+      record_fail "${case_name}" "expected unparseable thresholds to fall back to 5000"
+      return
+    fi
+  done
+  record_pass "${case_name}"
+}
+
+case_write_failure_no_notice() {
+  local case_name="write-failure-no-notice"
+  local scratch_dir="${TMP_DIR}/replace-blocked"
+  local payload
+  mkdir -p "${scratch_dir}"
+  python3 - "${scratch_dir}" <<'PY'
+import datetime
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+now = datetime.datetime.now()
+for offset in range(-2, 4):
+    ts = (now + datetime.timedelta(seconds=offset)).strftime("%Y-%m-%dT%H-%M-%S")
+    (root / "scratch-{}-bash.md".format(ts)).mkdir()
+PY
+  payload=$(payload_for plain 100)
+  run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=1
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDOUT}" ] && [ ! -s "${RUN_STDERR}" ] &&
+     [ -z "$(first_scratch_file "${scratch_dir}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected failed atomic replacement to emit no notice or final file"
+  fi
+}
+
+case_unwritable_dir_root_skip() {
+  local case_name="unwritable-dir-root-skip"
+  if [ "$(id -u)" = "0" ]; then
+    record_pass "${case_name}"
+    return
+  fi
+
+  local blocked_dir="${TMP_DIR}/unwritable"
+  local payload
+  mkdir -p "${blocked_dir}"
+  chmod 500 "${blocked_dir}"
+  payload=$(payload_for plain 100)
+  run_hook "${payload}" CK_SCRATCH_DIR="${blocked_dir}" CK_SCRATCH_THRESHOLD=1
+  chmod 700 "${blocked_dir}"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDOUT}" ] && [ ! -s "${RUN_STDERR}" ] &&
+     [ -z "$(first_scratch_file "${blocked_dir}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected an unwritable directory to fail silently without a notice"
+  fi
+}
+
+case_user_scratch_keeps_mode() {
+  local case_name="user-scratch-keeps-mode"
+  local scratch_dir="${TMP_DIR}/user-mode"
+  local payload
+  mkdir -p "${scratch_dir}"
+  chmod 755 "${scratch_dir}"
+  payload=$(payload_for plain 100)
+  run_hook "${payload}" CK_SCRATCH_DIR="${scratch_dir}" CK_SCRATCH_THRESHOLD=1
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ] &&
+     [ "$(dir_mode "${scratch_dir}")" = "755" ] && [ -n "$(first_scratch_file "${scratch_dir}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a user-supplied directory to retain mode 755"
+  fi
+}
+
+case_default_scratch_created_700() {
+  local case_name="default-scratch-created-700"
+  local temp_home="${TMP_DIR}/default-home"
+  local scratch_dir="${temp_home}/.claude/scratch/mode-case/memory"
+  local payload
+  mkdir -p "${temp_home}"
+  payload=$(payload_for plain 100)
+  RUN_STDOUT="${TMP_DIR}/stdout.$RANDOM"
+  RUN_STDERR="${TMP_DIR}/stderr.$RANDOM"
+  if printf '%s' "${payload}" | env -u CK_SCRATCH_DIR HOME="${temp_home}" CK_AGENT=mode-case CK_SCRATCH_THRESHOLD=1 \
+    bash "${HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ] &&
+     [ "$(dir_mode "${scratch_dir}")" = "700" ] && [ -n "$(first_scratch_file "${scratch_dir}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected the kit-created default directory to use mode 700"
+  fi
+}
+
+case_home_unset_fallback() {
+  local case_name="home-unset-fallback"
+  local temp_root="${TMP_DIR}/tmp-root"
+  local scratch_dir="${temp_root}/context-kit-scratch"
+  local payload
+  mkdir -p "${temp_root}"
+  payload=$(payload_for plain 100)
+  RUN_STDOUT="${TMP_DIR}/stdout.$RANDOM"
+  RUN_STDERR="${TMP_DIR}/stderr.$RANDOM"
+  if printf '%s' "${payload}" | env -u HOME -u CK_SCRATCH_DIR TMPDIR="${temp_root}" CK_SCRATCH_THRESHOLD=1 \
+    bash "${HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ] &&
+     [ "$(dir_mode "${scratch_dir}")" = "700" ] && [ -n "$(first_scratch_file "${scratch_dir}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected HOME-unset runs to use TMPDIR/context-kit-scratch mode 700"
+  fi
+}
+
+case_above_threshold
+case_below_threshold
+case_disabled
+case_invalid_inputs
+case_extraction_shapes
+case_threshold_override
+case_invalid_threshold_defaults
+case_write_failure_no_notice
+case_unwritable_dir_root_skip
+case_user_scratch_keeps_mode
+case_default_scratch_created_700
+case_home_unset_fallback
+finish


### PR DESCRIPTION
Second equipment (#1): the reactive half of the two-path context-hygiene design.

- `hooks/scratch-persist.sh` — fail-open launcher (env resolution, body lookup relative to own location, always exit 0)
- `hooks/scratch-persist.py` — persists >threshold tool output to the shared scratch dir with frontmatter; atomic write; `additionalContext` notice only after successful write; whole-body exception guard
- `docs/scratch-persist.md`, `examples/settings.json` (PostToolUse block added), `tests/test_scratch_persist.sh` (12 cases green; lg suites unaffected)

**Contract consistency with equip-1**: CK_* env, same scratch-dir resolution incl. HOME-unset fallback, chmod 700 scoped to kit-created default root only, guarded `<CONTEXT_KIT_DIR>` wiring form, English-only user-facing text.
**Implementation**: Codex GPT-5.6 Sol (high) / orchestration+commit: maintainer orchestrator
**Review seats**: GLM 5.2 + Opus 5 + Qwen (fallback Grok 4.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)