### PR TITLE
equip-3: delegation-brief validator PreToolUse hook (generalized)

### DIFF
--- a/docs/brief-validator.md
+++ b/docs/brief-validator.md
@@ -73,6 +73,8 @@ Required section tokens are matched as plain, case-sensitive substrings. The hoo
 
 ## Verify
 
+**Replace `<CONTEXT_KIT_DIR>` with your actual checkout path before running these snippets, or the file guard will exit `0` silently.**
+
 Run the self-check from the repository root:
 
 ```sh

--- a/docs/brief-validator.md
+++ b/docs/brief-validator.md
@@ -1,0 +1,106 @@
+# brief-validator
+
+## What/Why
+
+`brief-validator` is a `PreToolUse` hook for substantial `Agent` and `Task` delegations. It requires a three-layer brief with these canonical section tokens:
+
+- `## 実装仕様`
+- `## 実装チェック`
+- `## レビュー基準`
+
+The contract comes from the public [`family-dev-handbook`](https://github.com/caty-ai/family-dev-handbook), specifically [`docs/07-delegation-brief.md`](https://github.com/caty-ai/family-dev-handbook/blob/main/docs/07-delegation-brief.md) and [`templates/brief-template.md`](https://github.com/caty-ai/family-dev-handbook/blob/main/templates/brief-template.md). The three layers keep the requested implementation, self-verification, and reviewer acceptance criteria explicit at the delegation boundary.
+
+The hook blocks an incomplete substantial prompt with exit code `2`. Claude Code can then return the corrective message to the model so it retries the `Agent` or `Task` call with a complete brief. Short prompts and configured lightweight research subagent types pass through without validation.
+
+## Prerequisites
+
+- `python3 >= 3.9` must be available to Claude Code.
+- On macOS, if `python3` is missing because Command Line Tools are not installed yet, `xcode-select --install` is the usual first step.
+
+## Install
+
+1. Clone the repository.
+
+```sh
+git clone https://github.com/caty-ai/context-kit.git
+cd context-kit
+```
+
+2. Merge the hook into your existing Claude Code settings.
+
+Update either `~/.claude/settings.json` or `<project>/.claude/settings.json`. Merge this hook block into the existing file; do not overwrite unrelated settings.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/validate-subagent-brief.sh\"; if [ -f \"$f\" ]; then bash \"$f\"; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+3. Reload hooks.
+
+Restart Claude Code or run `/hooks` so the new wiring is picked up.
+
+## Wiring Notes
+
+The guarded command stays silent and exits `0` when `<CONTEXT_KIT_DIR>` has not been replaced or the checkout moves. This prevents a broken path from blocking every delegation before the validator is installed correctly.
+
+The launcher resolves `validate-subagent-brief.py` relative to its own location, follows symlinks when `readlink` is available, and fails open when the body or `python3` is unavailable. The Python body also fails open on malformed input, missing fields, unexpected input types, and internal errors. Exit code `2` is reserved for a genuine validation failure.
+
+Export hook environment variables from the shell, launcher, or app wrapper that starts Claude Code, then restart Claude Code. A variable attached to an unrelated tool command cannot change the environment of this `PreToolUse` hook.
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `CK_SKIP_BRIEF_VALIDATION` | Set to `1` in the environment that launches Claude Code to bypass validation. | unset |
+| `CK_BRIEF_REQUIRED_SECTIONS` | Pipe-delimited required section tokens. Empty, unset, or malformed values fall back to the canonical tokens. | `## 実装仕様\|## 実装チェック\|## レビュー基準` |
+| `CK_BRIEF_SKIP_SUBAGENT_TYPES` | Comma-separated subagent types that skip validation. An explicitly empty value skips no types. | `Explore,explore,general-purpose,claude-code-guide,statusline-setup,writer` |
+| `CK_BRIEF_MIN_PROMPT_CHARS` | Minimum prompt length that triggers validation. Empty or non-numeric values fall back to the default. | `500` |
+
+Required section tokens are matched as plain, case-sensitive substrings. The hook does not normalize case or parse Markdown heading levels.
+
+## Verify
+
+Run the self-check from the repository root:
+
+```sh
+bash tests/test_brief_validator.sh
+```
+
+Blocked probe: this must print an English corrective message that names all three missing canonical tokens and exit `2`.
+
+```sh
+python3 -c 'import json; print(json.dumps({"tool_name":"Agent","tool_input":{"subagent_type":"executor","prompt":"x" * 500}}))' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/validate-subagent-brief.sh"; if [ -f "$f" ]; then bash "$f"; fi'; echo $?
+```
+
+Compliant probe: this must print nothing and exit `0`.
+
+```sh
+python3 -c 'import json; print(json.dumps({"tool_name":"Agent","tool_input":{"subagent_type":"executor","prompt":"## 実装仕様\n## 実装チェック\n## レビュー基準\n" + "x" * 500}}))' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/validate-subagent-brief.sh"; if [ -f "$f" ]; then bash "$f"; fi'; echo $?
+```
+
+Short-prompt probe: this must print nothing and exit `0`.
+
+```sh
+echo '{"tool_name":"Task","tool_input":{"subagent_type":"executor","prompt":"quick lookup"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/validate-subagent-brief.sh"; if [ -f "$f" ]; then bash "$f"; fi'; echo $?
+```
+
+Optional syntax, AST, and JSON checks:
+
+```sh
+bash -n hooks/validate-subagent-brief.sh tests/test_brief_validator.sh
+python3 -B -c "import ast; ast.parse(open('hooks/validate-subagent-brief.py').read())"
+python3 -m json.tool examples/settings.json >/dev/null
+```

--- a/examples/settings.json
+++ b/examples/settings.json
@@ -9,6 +9,15 @@
             "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/lg-enforcer.py\"; if [ -f \"$f\" ]; then python3 \"$f\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/validate-subagent-brief.sh\"; if [ -f \"$f\" ]; then bash \"$f\"; fi'"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/hooks/scratch-persist.sh
+++ b/hooks/scratch-persist.sh
@@ -19,6 +19,7 @@ else
   export CK_SCRATCH_DIR_IS_DEFAULT=1
 fi
 
+# This duplicated launcher pattern is intentionally copy-kept so each hook stays single-file installable.
 SCRIPT_PATH=$0
 if command -v readlink >/dev/null 2>&1; then
   LINK_COUNT=0

--- a/hooks/validate-subagent-brief.py
+++ b/hooks/validate-subagent-brief.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Require a three-layer brief for substantial Agent/Task delegations."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import List, Set
+
+
+DEFAULT_REQUIRED_SECTIONS = [
+    "## 実装仕様",
+    "## 実装チェック",
+    "## レビュー基準",
+]
+DEFAULT_SKIP_SUBAGENT_TYPES = {
+    "Explore",
+    "explore",
+    "general-purpose",
+    "claude-code-guide",
+    "statusline-setup",
+    "writer",
+}
+DEFAULT_MIN_PROMPT_CHARS = 500
+SUPPORTED_TOOLS = {"Agent", "Task"}
+
+
+def required_sections_from_env() -> List[str]:
+    raw = os.environ.get("CK_BRIEF_REQUIRED_SECTIONS")
+    if not raw:
+        return list(DEFAULT_REQUIRED_SECTIONS)
+
+    sections = [section.strip() for section in raw.split("|")]
+    if any(not section for section in sections):
+        return list(DEFAULT_REQUIRED_SECTIONS)
+    return sections
+
+
+def skip_subagent_types_from_env() -> Set[str]:
+    raw = os.environ.get("CK_BRIEF_SKIP_SUBAGENT_TYPES")
+    if raw is None:
+        return set(DEFAULT_SKIP_SUBAGENT_TYPES)
+    return {entry.strip() for entry in raw.split(",") if entry.strip()}
+
+
+def min_prompt_chars_from_env() -> int:
+    try:
+        return int(
+            os.environ.get(
+                "CK_BRIEF_MIN_PROMPT_CHARS", str(DEFAULT_MIN_PROMPT_CHARS)
+            )
+        )
+    except (TypeError, ValueError, OverflowError):
+        return DEFAULT_MIN_PROMPT_CHARS
+
+
+def render_skeleton(sections: List[str]) -> str:
+    guidance = [
+        "- State the deliverable, constraints, and relevant context.",
+        "- List concrete self-verification steps and completion checks.",
+        "- Define observable reviewer criteria and acceptance conditions.",
+    ]
+    blocks = []
+    for index, section in enumerate(sections):
+        detail = guidance[index] if index < len(guidance) else "- State the required details."
+        blocks.append("{}\n{}".format(section, detail))
+    return "\n\n".join(blocks)
+
+
+def block_message(
+    tool_name: str,
+    subagent_type: str,
+    missing: List[str],
+    sections: List[str],
+) -> str:
+    default_skips = ", ".join(sorted(DEFAULT_SKIP_SUBAGENT_TYPES))
+    return (
+        "[validate-subagent-brief] Blocked {} delegation for subagent type '{}'.\n\n"
+        "A substantial delegation prompt must include the active three-layer brief.\n"
+        "Missing sections: {}\n\n"
+        "Minimal skeleton:\n\n"
+        "{}\n\n"
+        "Canonical rulebook:\n"
+        "- https://github.com/caty-ai/family-dev-handbook/blob/main/docs/07-delegation-brief.md\n"
+        "- https://github.com/caty-ai/family-dev-handbook/blob/main/templates/brief-template.md\n\n"
+        "For lightweight research, use a subagent type listed in "
+        "CK_BRIEF_SKIP_SUBAGENT_TYPES (defaults: {}).\n"
+        "To bypass temporarily, set CK_SKIP_BRIEF_VALIDATION=1 in the environment "
+        "that launches Claude Code, then restart it."
+    ).format(
+        tool_name,
+        subagent_type,
+        ", ".join(missing),
+        render_skeleton(sections),
+        default_skips,
+    )
+
+
+def run() -> int:
+    if os.environ.get("CK_SKIP_BRIEF_VALIDATION") == "1":
+        return 0
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 0
+
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        return 0
+
+    tool_name = data.get("tool_name")
+    if tool_name not in SUPPORTED_TOOLS:
+        return 0
+
+    tool_input = data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    subagent_type = tool_input.get("subagent_type")
+    prompt = tool_input.get("prompt")
+    if not isinstance(subagent_type, str) or not subagent_type:
+        return 0
+    if not isinstance(prompt, str):
+        return 0
+
+    if subagent_type in skip_subagent_types_from_env():
+        return 0
+    if len(prompt) < min_prompt_chars_from_env():
+        return 0
+
+    sections = required_sections_from_env()
+    missing = [section for section in sections if section not in prompt]
+    if not missing:
+        return 0
+
+    print(
+        block_message(tool_name, subagent_type, missing, sections),
+        file=sys.stderr,
+    )
+    return 2
+
+
+def main() -> int:
+    try:
+        return run()
+    except BaseException:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/validate-subagent-brief.py
+++ b/hooks/validate-subagent-brief.py
@@ -56,16 +56,24 @@ def min_prompt_chars_from_env() -> int:
 
 
 def render_skeleton(sections: List[str]) -> str:
-    guidance = [
+    canonical_guidance = [
         "- State the deliverable, constraints, and relevant context.",
         "- List concrete self-verification steps and completion checks.",
         "- Define observable reviewer criteria and acceptance conditions.",
     ]
+    use_canonical_guidance = sections == DEFAULT_REQUIRED_SECTIONS
     blocks = []
     for index, section in enumerate(sections):
-        detail = guidance[index] if index < len(guidance) else "- State the required details."
+        if use_canonical_guidance and index < len(canonical_guidance):
+            detail = canonical_guidance[index]
+        else:
+            detail = "- State what this section requires."
         blocks.append("{}\n{}".format(section, detail))
     return "\n\n".join(blocks)
+
+
+def sanitize_subagent_type(subagent_type: str) -> str:
+    return subagent_type.replace("\r", " ").replace("\n", " ")[:100]
 
 
 def block_message(
@@ -73,8 +81,9 @@ def block_message(
     subagent_type: str,
     missing: List[str],
     sections: List[str],
+    skip_subagent_types: Set[str],
 ) -> str:
-    default_skips = ", ".join(sorted(DEFAULT_SKIP_SUBAGENT_TYPES))
+    effective_skips = ", ".join(sorted(skip_subagent_types))
     return (
         "[validate-subagent-brief] Blocked {} delegation for subagent type '{}'.\n\n"
         "A substantial delegation prompt must include the active three-layer brief.\n"
@@ -85,15 +94,15 @@ def block_message(
         "- https://github.com/caty-ai/family-dev-handbook/blob/main/docs/07-delegation-brief.md\n"
         "- https://github.com/caty-ai/family-dev-handbook/blob/main/templates/brief-template.md\n\n"
         "For lightweight research, use a subagent type listed in "
-        "CK_BRIEF_SKIP_SUBAGENT_TYPES (defaults: {}).\n"
+        "CK_BRIEF_SKIP_SUBAGENT_TYPES (effective: {}).\n"
         "To bypass temporarily, set CK_SKIP_BRIEF_VALIDATION=1 in the environment "
         "that launches Claude Code, then restart it."
     ).format(
         tool_name,
-        subagent_type,
+        sanitize_subagent_type(subagent_type),
         ", ".join(missing),
         render_skeleton(sections),
-        default_skips,
+        effective_skips,
     )
 
 
@@ -124,7 +133,8 @@ def run() -> int:
     if not isinstance(prompt, str):
         return 0
 
-    if subagent_type in skip_subagent_types_from_env():
+    skip_subagent_types = skip_subagent_types_from_env()
+    if subagent_type in skip_subagent_types:
         return 0
     if len(prompt) < min_prompt_chars_from_env():
         return 0
@@ -135,7 +145,13 @@ def run() -> int:
         return 0
 
     print(
-        block_message(tool_name, subagent_type, missing, sections),
+        block_message(
+            tool_name,
+            subagent_type,
+            missing,
+            sections,
+            skip_subagent_types,
+        ),
         file=sys.stderr,
     )
     return 2
@@ -144,6 +160,7 @@ def run() -> int:
 def main() -> int:
     try:
         return run()
+    # Hooks fail open even on SystemExit; callers should rely on the return value, not sys.exit.
     except BaseException:
         return 0
 

--- a/hooks/validate-subagent-brief.py
+++ b/hooks/validate-subagent-brief.py
@@ -83,7 +83,7 @@ def block_message(
     sections: List[str],
     skip_subagent_types: Set[str],
 ) -> str:
-    effective_skips = ", ".join(sorted(skip_subagent_types))
+    effective_skips = "effective: " + ", ".join(sorted(skip_subagent_types)) if skip_subagent_types else "none configured"
     return (
         "[validate-subagent-brief] Blocked {} delegation for subagent type '{}'.\n\n"
         "A substantial delegation prompt must include the active three-layer brief.\n"
@@ -94,7 +94,7 @@ def block_message(
         "- https://github.com/caty-ai/family-dev-handbook/blob/main/docs/07-delegation-brief.md\n"
         "- https://github.com/caty-ai/family-dev-handbook/blob/main/templates/brief-template.md\n\n"
         "For lightweight research, use a subagent type listed in "
-        "CK_BRIEF_SKIP_SUBAGENT_TYPES (effective: {}).\n"
+        "CK_BRIEF_SKIP_SUBAGENT_TYPES ({}).\n"
         "To bypass temporarily, set CK_SKIP_BRIEF_VALIDATION=1 in the environment "
         "that launches Claude Code, then restart it."
     ).format(

--- a/hooks/validate-subagent-brief.sh
+++ b/hooks/validate-subagent-brief.sh
@@ -48,7 +48,7 @@ if [ "${STATUS}" -ne 2 ]; then
   exit 0
 fi
 
-if grep -Fq '[validate-subagent-brief] Blocked ' "${ERROR_FILE}"; then
+if grep -Fq '[validate-subagent-brief] Blocked ' "${ERROR_FILE}" 2>/dev/null; then
   cat "${ERROR_FILE}" >&2
   exit 2
 fi

--- a/hooks/validate-subagent-brief.sh
+++ b/hooks/validate-subagent-brief.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# validate-subagent-brief - fail-open launcher for the Agent/Task PreToolUse hook.
+
+set -u
+
+if [ "${CK_SKIP_BRIEF_VALIDATION:-0}" = "1" ]; then
+  exit 0
+fi
+
+SCRIPT_PATH=$0
+if command -v readlink >/dev/null 2>&1; then
+  LINK_COUNT=0
+  MAX_LINKS=40
+  while [ -L "${SCRIPT_PATH}" ]; do
+    if [ "${LINK_COUNT}" -ge "${MAX_LINKS}" ]; then
+      exit 0
+    fi
+    LINK_COUNT=$((LINK_COUNT + 1))
+    LINK_TARGET=$(readlink "${SCRIPT_PATH}" 2>/dev/null) || break
+    case "${LINK_TARGET}" in
+      /*)
+        SCRIPT_PATH="${LINK_TARGET}"
+        ;;
+      *)
+        SCRIPT_DIR=$(dirname "${SCRIPT_PATH}" 2>/dev/null) || break
+        SCRIPT_PATH="${SCRIPT_DIR}/${LINK_TARGET}"
+        ;;
+    esac
+  done
+fi
+
+BODY_DIR=$(cd "$(dirname "${SCRIPT_PATH}")" 2>/dev/null && pwd -P) || exit 0
+BODY="${BODY_DIR}/validate-subagent-brief.py"
+if [ ! -f "${BODY}" ] || [ ! -r "${BODY}" ] || ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+ERROR_FILE=$(mktemp -t ck-brief-validator.XXXXXX 2>/dev/null) || exit 0
+cleanup() {
+  rm -f "${ERROR_FILE}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+python3 "${BODY}" >/dev/null 2>"${ERROR_FILE}"
+STATUS=$?
+if [ "${STATUS}" -ne 2 ]; then
+  exit 0
+fi
+
+FIRST_LINE=""
+IFS= read -r FIRST_LINE < "${ERROR_FILE}" || exit 0
+case "${FIRST_LINE}" in
+  '[validate-subagent-brief] Blocked '*)
+    if cat "${ERROR_FILE}" >&2; then
+      exit 2
+    fi
+    ;;
+esac
+exit 0

--- a/hooks/validate-subagent-brief.sh
+++ b/hooks/validate-subagent-brief.sh
@@ -7,6 +7,7 @@ if [ "${CK_SKIP_BRIEF_VALIDATION:-0}" = "1" ]; then
   exit 0
 fi
 
+# This duplicated launcher pattern is intentionally copy-kept so each hook stays single-file installable.
 SCRIPT_PATH=$0
 if command -v readlink >/dev/null 2>&1; then
   LINK_COUNT=0
@@ -47,13 +48,8 @@ if [ "${STATUS}" -ne 2 ]; then
   exit 0
 fi
 
-FIRST_LINE=""
-IFS= read -r FIRST_LINE < "${ERROR_FILE}" || exit 0
-case "${FIRST_LINE}" in
-  '[validate-subagent-brief] Blocked '*)
-    if cat "${ERROR_FILE}" >&2; then
-      exit 2
-    fi
-    ;;
-esac
+if grep -Fq '[validate-subagent-brief] Blocked ' "${ERROR_FILE}"; then
+  cat "${ERROR_FILE}" >&2
+  exit 2
+fi
 exit 0

--- a/tests/test_brief_validator.sh
+++ b/tests/test_brief_validator.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+HOOK="${ROOT}/hooks/validate-subagent-brief.sh"
+TMP_DIR=$(mktemp -d)
+PASS_COUNT=0
+FAIL_COUNT=0
+RUN_STDOUT=""
+RUN_STDERR=""
+RUN_STATUS=0
+
+cleanup() {
+  chmod -R u+rwx "${TMP_DIR}" 2>/dev/null || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+record_pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+record_fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+finish() {
+  if [ "${FAIL_COUNT}" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+long_text() {
+  python3 -c 'print("x" * 600, end="")'
+}
+
+payload_for() {
+  local tool_name="$1"
+  local subagent_type="$2"
+  local prompt="$3"
+  python3 - "${tool_name}" "${subagent_type}" "${prompt}" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "tool_name": sys.argv[1],
+    "tool_input": {
+        "subagent_type": sys.argv[2],
+        "prompt": sys.argv[3],
+    },
+}))
+PY
+}
+
+run_hook() {
+  local payload="$1"
+  shift
+  RUN_STDOUT="${TMP_DIR}/stdout.$RANDOM"
+  RUN_STDERR="${TMP_DIR}/stderr.$RANDOM"
+  if printf '%s' "${payload}" | env "$@" bash "${HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+}
+
+canonical_prompt() {
+  printf '## 実装仕様\n## 実装チェック\n## レビュー基準\n%s' "$(long_text)"
+}
+
+case_missing_all_blocks() {
+  local case_name="missing-all-blocks"
+  local payload
+  payload=$(payload_for Agent executor "$(long_text)")
+  run_hook "${payload}"
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fq 'Missing sections: ## 実装仕様, ## 実装チェック, ## レビュー基準' "${RUN_STDERR}" &&
+     grep -Fq 'https://github.com/caty-ai/family-dev-handbook/blob/main/docs/07-delegation-brief.md' "${RUN_STDERR}" &&
+     grep -Fq 'CK_SKIP_BRIEF_VALIDATION=1' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a long incomplete prompt to name all missing sections and exit 2"
+  fi
+}
+
+case_compliant_allowed() {
+  local case_name="compliant-allowed"
+  local payload
+  payload=$(payload_for Agent executor "$(canonical_prompt)")
+  run_hook "${payload}"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDOUT}" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected all three canonical sections to pass silently"
+  fi
+}
+
+case_one_missing_blocks_exactly() {
+  local case_name="one-missing-blocks-exactly"
+  local prompt
+  local payload
+  local missing_line
+  prompt=$(printf '## 実装仕様\n## レビュー基準\n%s' "$(long_text)")
+  payload=$(payload_for Agent executor "${prompt}")
+  run_hook "${payload}"
+  missing_line=$(grep '^Missing sections:' "${RUN_STDERR}" || true)
+  if [ "${RUN_STATUS}" = "2" ] && [ "${missing_line}" = 'Missing sections: ## 実装チェック' ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected the missing-section line to name exactly the absent section"
+  fi
+}
+
+case_short_allowed() {
+  local case_name="short-allowed"
+  run_hook "$(payload_for Agent executor 'quick lookup')"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a short prompt to skip validation"
+  fi
+}
+
+case_default_skip_allowed() {
+  local case_name="default-writer-skip-allowed"
+  run_hook "$(payload_for Agent writer "$(long_text)")"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected the default writer type to skip validation"
+  fi
+}
+
+case_skip_override_replaces_defaults() {
+  local case_name="skip-override-replaces-defaults"
+  run_hook "$(payload_for Agent research-lite "$(long_text)")" CK_BRIEF_SKIP_SUBAGENT_TYPES=research-lite
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected the configured research type to skip validation"
+    return
+  fi
+  run_hook "$(payload_for Agent writer "$(long_text)")" CK_BRIEF_SKIP_SUBAGENT_TYPES=research-lite
+  if [ "${RUN_STATUS}" = "2" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected an override to replace rather than extend the default skip list"
+  fi
+}
+
+case_custom_sections_enforced() {
+  local case_name="custom-sections-enforced"
+  local required='## Goal|## Self-check|## Review criteria'
+  local custom_prompt
+  custom_prompt=$(printf '## Goal\n## Self-check\n## Review criteria\n%s' "$(long_text)")
+  run_hook "$(payload_for Agent executor "${custom_prompt}")" CK_BRIEF_REQUIRED_SECTIONS="${required}"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected all configured section tokens to pass"
+    return
+  fi
+  run_hook "$(payload_for Agent executor "$(canonical_prompt)")" CK_BRIEF_REQUIRED_SECTIONS="${required}"
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fq 'Missing sections: ## Goal, ## Self-check, ## Review criteria' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected canonical tokens alone to fail under a custom required set"
+  fi
+}
+
+case_matching_is_exact() {
+  local case_name="matching-is-case-sensitive-and-not-normalized"
+  local required='## Goal|## Self-check|## Review criteria'
+  local lowercase_prompt
+  local wrong_level_prompt
+  lowercase_prompt=$(printf '## goal\n## self-check\n## review criteria\n%s' "$(long_text)")
+  run_hook "$(payload_for Agent executor "${lowercase_prompt}")" CK_BRIEF_REQUIRED_SECTIONS="${required}"
+  if [ "${RUN_STATUS}" != "2" ]; then
+    record_fail "${case_name}" "expected case variants to remain missing"
+    return
+  fi
+  wrong_level_prompt=$(canonical_prompt)
+  wrong_level_prompt=${wrong_level_prompt#\#}
+  run_hook "$(payload_for Agent executor "${wrong_level_prompt}")"
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fxq 'Missing sections: ## 実装仕様' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a one-hash heading not to satisfy the exact token"
+  fi
+}
+
+case_threshold_override_and_fallback() {
+  local case_name="threshold-override-and-fallback"
+  local prompt
+  prompt=$(python3 -c 'print("x" * 120, end="")')
+  run_hook "$(payload_for Agent executor "${prompt}")" CK_BRIEF_MIN_PROMPT_CHARS=100
+  if [ "${RUN_STATUS}" != "2" ]; then
+    record_fail "${case_name}" "expected the numeric threshold override to trigger validation"
+    return
+  fi
+  run_hook "$(payload_for Agent executor "${prompt}")" CK_BRIEF_MIN_PROMPT_CHARS=not-a-number
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a non-numeric threshold to fall back to 500"
+  fi
+}
+
+case_task_and_other_tools() {
+  local case_name="task-accepted-other-tools-allowed"
+  run_hook "$(payload_for Task executor "$(long_text)")"
+  if [ "${RUN_STATUS}" != "2" ]; then
+    record_fail "${case_name}" "expected Task to use the same validation path as Agent"
+    return
+  fi
+  run_hook "$(payload_for Bash executor "$(long_text)")"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected non-Agent/Task tools to pass through"
+  fi
+}
+
+case_malformed_inputs_fail_open() {
+  local case_name="malformed-inputs-fail-open"
+  local payload
+  local payloads=(
+    ''
+    'garbage'
+    '[]'
+    '{}'
+    '{"tool_name":"Agent"}'
+    '{"tool_name":"Agent","tool_input":{"prompt":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}'
+    '{"tool_name":"Agent","tool_input":{"subagent_type":"executor","prompt":42}}'
+  )
+  for payload in "${payloads[@]}"; do
+    run_hook "${payload}" CK_BRIEF_MIN_PROMPT_CHARS=1
+    if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDOUT}" ] || [ -s "${RUN_STDERR}" ]; then
+      record_fail "${case_name}" "expected empty, malformed, non-dict, missing-field, and non-string inputs to pass silently"
+      return
+    fi
+  done
+  record_pass "${case_name}"
+}
+
+case_launcher_bypass() {
+  local case_name="launcher-bypass"
+  run_hook "$(payload_for Agent executor "$(long_text)")" CK_SKIP_BRIEF_VALIDATION=1
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDOUT}" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected the launcher environment bypass to pass silently"
+  fi
+}
+
+case_missing_body_fail_open() {
+  local case_name="missing-body-fail-open"
+  local isolated_dir="${TMP_DIR}/missing-body"
+  local isolated_hook="${isolated_dir}/validate-subagent-brief.sh"
+  local payload
+  mkdir -p "${isolated_dir}"
+  cp "${HOOK}" "${isolated_hook}"
+  payload=$(payload_for Agent executor "$(long_text)")
+  RUN_STDOUT="${TMP_DIR}/missing-body.stdout"
+  RUN_STDERR="${TMP_DIR}/missing-body.stderr"
+  if bash "${isolated_hook}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}" <<<"${payload}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDOUT}" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a launcher without its Python body to fail open silently"
+  fi
+}
+
+case_interpreter_status_two_fail_open() {
+  local case_name="interpreter-status-two-fail-open"
+  local fake_bin="${TMP_DIR}/fake-bin"
+  local fake_python="${fake_bin}/python3"
+  local payload
+  mkdir -p "${fake_bin}"
+  printf '#!/bin/sh\nprintf "simulated interpreter failure\\n" >&2\nexit 2\n' > "${fake_python}"
+  chmod 755 "${fake_python}"
+  payload=$(payload_for Agent executor "$(long_text)")
+  run_hook "${payload}" PATH="${fake_bin}:${PATH}"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDOUT}" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a non-validator status 2 to fail open silently"
+  fi
+}
+
+case_missing_all_blocks
+case_compliant_allowed
+case_one_missing_blocks_exactly
+case_short_allowed
+case_default_skip_allowed
+case_skip_override_replaces_defaults
+case_custom_sections_enforced
+case_matching_is_exact
+case_threshold_override_and_fallback
+case_task_and_other_tools
+case_malformed_inputs_fail_open
+case_launcher_bypass
+case_missing_body_fail_open
+case_interpreter_status_two_fail_open
+finish

--- a/tests/test_brief_validator.sh
+++ b/tests/test_brief_validator.sh
@@ -37,6 +37,10 @@ long_text() {
   python3 -c 'print("x" * 600, end="")'
 }
 
+repeated_text() {
+  python3 -c 'import sys; print("x" * int(sys.argv[1]), end="")' "$1"
+}
+
 payload_for() {
   local tool_name="$1"
   local subagent_type="$2"
@@ -124,6 +128,22 @@ case_short_allowed() {
   fi
 }
 
+case_threshold_boundary() {
+  local case_name="threshold-boundary"
+  run_hook "$(payload_for Agent executor "$(repeated_text 499)")"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected a 499-character prompt to skip validation"
+    return
+  fi
+  run_hook "$(payload_for Agent executor "$(repeated_text 500)")"
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fq 'Missing sections: ## 実装仕様, ## 実装チェック, ## レビュー基準' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a 500-character prompt to trigger validation"
+  fi
+}
+
 case_default_skip_allowed() {
   local case_name="default-writer-skip-allowed"
   run_hook "$(payload_for Agent writer "$(long_text)")"
@@ -131,6 +151,17 @@ case_default_skip_allowed() {
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "expected the default writer type to skip validation"
+  fi
+}
+
+case_skip_matching_is_exact() {
+  local case_name="skip-matching-is-exact"
+  run_hook "$(payload_for Agent writer2 "$(long_text)")"
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fq "subagent type 'writer2'" "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected writer2 not to inherit the default writer skip"
   fi
 }
 
@@ -146,6 +177,18 @@ case_skip_override_replaces_defaults() {
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "expected an override to replace rather than extend the default skip list"
+  fi
+}
+
+case_skip_override_message_uses_effective_list() {
+  local case_name="skip-override-message-uses-effective-list"
+  run_hook "$(payload_for Agent writer "$(long_text)")" CK_BRIEF_SKIP_SUBAGENT_TYPES=research-lite
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fq 'CK_BRIEF_SKIP_SUBAGENT_TYPES (effective: research-lite).' "${RUN_STDERR}" &&
+     ! grep -Fq 'Explore' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected the block message to show only the effective skip list"
   fi
 }
 
@@ -165,6 +208,38 @@ case_custom_sections_enforced() {
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "expected canonical tokens alone to fail under a custom required set"
+  fi
+}
+
+case_custom_sections_use_generic_skeleton_guidance() {
+  local case_name="custom-sections-use-generic-skeleton-guidance"
+  local required='## Goal|## Self-check|## Review criteria'
+  run_hook "$(payload_for Agent executor "$(long_text)")" CK_BRIEF_REQUIRED_SECTIONS="${required}"
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fq '## Goal' "${RUN_STDERR}" &&
+     grep -Fq -- '- State what this section requires.' "${RUN_STDERR}" &&
+     ! grep -Fq -- '- State the deliverable, constraints, and relevant context.' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected custom required sections to use generic skeleton guidance"
+  fi
+}
+
+case_reordered_canonical_sections_use_generic_skeleton_guidance() {
+  local case_name="reordered-canonical-sections-use-generic-skeleton-guidance"
+  local required='## レビュー基準|## 実装仕様|## 実装チェック'
+  run_hook "$(payload_for Agent executor "$(long_text)")" CK_BRIEF_REQUIRED_SECTIONS="${required}"
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fq '## レビュー基準' "${RUN_STDERR}" &&
+     grep -Fq '## 実装仕様' "${RUN_STDERR}" &&
+     grep -Fq '## 実装チェック' "${RUN_STDERR}" &&
+     [ "$(grep -Fc -- '- State what this section requires.' "${RUN_STDERR}")" = "3" ] &&
+     ! grep -Fq -- '- State the deliverable, constraints, and relevant context.' "${RUN_STDERR}" &&
+     ! grep -Fq -- '- List concrete self-verification steps and completion checks.' "${RUN_STDERR}" &&
+     ! grep -Fq -- '- Define observable reviewer criteria and acceptance conditions.' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected reordered canonical sections to use only generic skeleton guidance"
   fi
 }
 
@@ -190,6 +265,21 @@ case_matching_is_exact() {
   fi
 }
 
+case_malformed_required_sections_fall_back() {
+  local case_name="malformed-required-sections-fall-back"
+  local malformed_values=('a||b' '|')
+  local value
+  for value in "${malformed_values[@]}"; do
+    run_hook "$(payload_for Agent executor "$(long_text)")" CK_BRIEF_REQUIRED_SECTIONS="${value}"
+    if [ "${RUN_STATUS}" != "2" ] ||
+       ! grep -Fq 'Missing sections: ## 実装仕様, ## 実装チェック, ## レビュー基準' "${RUN_STDERR}"; then
+      record_fail "${case_name}" "expected malformed required sections (${value}) to fall back to canonical defaults"
+      return
+    fi
+  done
+  record_pass "${case_name}"
+}
+
 case_threshold_override_and_fallback() {
   local case_name="threshold-override-and-fallback"
   local prompt
@@ -204,6 +294,37 @@ case_threshold_override_and_fallback() {
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "expected a non-numeric threshold to fall back to 500"
+  fi
+}
+
+case_subagent_type_is_sanitized() {
+  local case_name="subagent-type-is-sanitized"
+  local weird_type=$'writer\r\nwith-break'
+  local first_line
+  run_hook "$(payload_for Agent "${weird_type}" "$(long_text)")"
+  first_line=$(head -n 1 "${RUN_STDERR}" || true)
+  if [ "${RUN_STATUS}" = "2" ] &&
+     [ "${first_line}" = "[validate-subagent-brief] Blocked Agent delegation for subagent type 'writer  with-break'." ] &&
+     ! grep -q $'\r' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected CR/LF in the echoed subagent type to be flattened"
+  fi
+}
+
+case_subagent_type_is_truncated() {
+  local case_name="subagent-type-is-truncated"
+  local long_type
+  local first_line
+  long_type=$(python3 -c 'print("t" * 120, end="")')
+  run_hook "$(payload_for Agent "${long_type}" "$(long_text)")"
+  first_line=$(head -n 1 "${RUN_STDERR}" || true)
+  if [ "${RUN_STATUS}" = "2" ] &&
+     [ "${#first_line}" = "172" ] &&
+     printf '%s\n' "${first_line}" | grep -Eq "^\\[validate-subagent-brief\\] Blocked Agent delegation for subagent type 't{100}'\\.$"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected the echoed subagent type to be truncated to 100 characters"
   fi
 }
 
@@ -293,18 +414,50 @@ case_interpreter_status_two_fail_open() {
   fi
 }
 
+case_interpreter_noise_before_blocked_sentinel() {
+  local case_name="interpreter-noise-before-blocked-sentinel"
+  local fake_bin="${TMP_DIR}/shim-bin"
+  local fake_python="${fake_bin}/python3"
+  local payload
+  mkdir -p "${fake_bin}"
+  cat > "${fake_python}" <<EOF
+#!/bin/sh
+printf 'python shim noise\n' >&2
+exec "$(command -v python3)" "\$@"
+EOF
+  chmod 755 "${fake_python}"
+  payload=$(payload_for Agent executor "$(long_text)")
+  run_hook "${payload}" PATH="${fake_bin}:${PATH}"
+  if [ "${RUN_STATUS}" = "2" ] &&
+     grep -Fq 'python shim noise' "${RUN_STDERR}" &&
+     grep -Fq '[validate-subagent-brief] Blocked Agent delegation' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected shim noise before the sentinel to preserve blocking behavior"
+  fi
+}
+
 case_missing_all_blocks
 case_compliant_allowed
 case_one_missing_blocks_exactly
 case_short_allowed
+case_threshold_boundary
 case_default_skip_allowed
+case_skip_matching_is_exact
 case_skip_override_replaces_defaults
+case_skip_override_message_uses_effective_list
 case_custom_sections_enforced
+case_custom_sections_use_generic_skeleton_guidance
+case_reordered_canonical_sections_use_generic_skeleton_guidance
 case_matching_is_exact
+case_malformed_required_sections_fall_back
 case_threshold_override_and_fallback
+case_subagent_type_is_sanitized
+case_subagent_type_is_truncated
 case_task_and_other_tools
 case_malformed_inputs_fail_open
 case_launcher_bypass
 case_missing_body_fail_open
 case_interpreter_status_two_fail_open
+case_interpreter_noise_before_blocked_sentinel
 finish


### PR DESCRIPTION
Third equipment (#1): machine-checkable delegation quality.

- `hooks/validate-subagent-brief.sh` + `.py` — PreToolUse(Agent|Task) hook: substantial prompts (≥500 chars, non-research subagent types) must contain the canonical 3-layer brief headings (verbatim from the public family-dev-handbook — `docs/07-delegation-brief.md` / `templates/brief-template.md`). Exit 2 + English corrective skeleton on miss; fail-open everywhere else.
- Env: `CK_SKIP_BRIEF_VALIDATION` / `CK_BRIEF_REQUIRED_SECTIONS` (`|`-delimited) / `CK_BRIEF_SKIP_SUBAGENT_TYPES` / `CK_BRIEF_MIN_PROMPT_CHARS`.
- Honest bypass wording: launcher-env only (the original promised a same-line env that cannot reach this hook type).
- `docs/brief-validator.md`, `examples/settings.json` (Agent|Task block), `tests/test_brief_validator.sh` (14 cases; all 4 suites green).

**Implementation**: Codex GPT-5.6 Sol (high) / orchestration+commit: maintainer orchestrator
**Review seats**: GLM 5.2 + Opus 5 + Qwen (fallback Grok 4.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)