### PR TITLE
equip-4: three safety hooks generalized

### DIFF
--- a/docs/safety-hooks.md
+++ b/docs/safety-hooks.md
@@ -15,6 +15,13 @@ Together they cover three common failure classes: destructive commands, accident
 - `python3 >= 3.9` is required for `rm-enforcer.py`.
 - `node >= 18` is required for the two `.mjs` hooks.
 
+If the required interpreter is missing from the `PATH` that launches Claude Code, including an nvm/fnm-managed shell, the affected hooks are silently unprotected because exit `127` is non-blocking. Check each interpreter with one line:
+
+```sh
+command -v python3 && python3 --version
+command -v node && node --version
+```
+
 The guarded wiring below checks that the hook is a readable file and that its interpreter exists, then stays quiet with exit `0` when either prerequisite is absent. A bare attempt to run `node` on a machine without Node normally exits `127`; Claude Code treats that hook failure as non-blocking, but the guard avoids the repeated stderr noise. Internal parsing, timeout, and runtime failures also fail open. Exit `2` is reserved for a genuine detection.
 
 ## Install
@@ -96,9 +103,18 @@ Write and Edit tool calls have no Bash command string. `CK_API_KEY_DETECT_DISABL
 
 On detection, the API-key hook writes a local rotation-evidence report and prints its path to stderr. The report contains the tool name, the target file path when present, provider names, and redacted matches that keep only the first eight characters. It does not store the scanned command/content or the full matched key.
 
-Evidence files are created with mode `0600`. The kit-managed default scratch root is hardened to `0700`; a user-configured `CK_SCRATCH_DIR` retains its existing directory permissions. Evidence is never written into the repository unless the operator explicitly points `CK_SCRATCH_DIR` there.
+Evidence files are created with mode `0600`. The kit-managed default scratch root is hardened to `0700`; a user-configured `CK_SCRATCH_DIR` retains its existing directory permissions. Relative `CK_SCRATCH_DIR` values resolve under the default scratch root rather than the current working directory. Evidence is never written into the repository unless the operator explicitly points `CK_SCRATCH_DIR` there.
 
-Write/Edit calls targeting these intentional credential-file forms are excluded exactly as in the source hook: `.env`, `.env.<lowercase-suffix>`, `secret.json`, and `secrets.json`. The exclusion applies only when the file path ends with one of those slash-prefixed names. Bash commands are still scanned even when they mention an env file.
+Write/Edit calls targeting these intentional credential-file forms are excluded: `.env`, `.env.<lowercase-suffix>`, `secret.json`, and `secrets.json`. Unlike the source hook, this generalized hook deliberately drops its personal env-file exclusion, so other env filenames are scanned. The exclusion applies only when the file path ends with one of those slash-prefixed names. Bash commands are still scanned even when they mention an env file.
+
+### Known gaps (inherited from the originals)
+
+- `rm -rf /*` glob form
+- `git push -f` short flag
+- `--visibility=public` equals form
+- Repository-visibility changes through `gh api`
+
+These gaps preserve source-hook parity; PRs are welcome.
 
 ## Verify
 

--- a/docs/safety-hooks.md
+++ b/docs/safety-hooks.md
@@ -1,0 +1,156 @@
+# safety hooks
+
+## What/Why
+
+This equipment provides three independent `PreToolUse` safety hooks:
+
+- `rm-enforcer.py` blocks destructive shell operations such as root or home deletion, infrastructure destruction, destructive SQL, forced pushes to `main` or `master`, device overwrites, and shell-startup-file overwrites.
+- `private-repo-enforcer.mjs` requires explicit visibility for `gh repo create`, blocks public creation, and blocks changing a repository to public.
+- `api-key-leak-detector.mjs` blocks recognized provider credential patterns in Bash commands and in Write/Edit content before the tool runs.
+
+Together they cover three common failure classes: destructive commands, accidental public repositories, and credential leakage into command lines or files. They are pattern-based safeguards, not shell parsers or secret-management systems.
+
+## Prerequisites
+
+- `python3 >= 3.9` is required for `rm-enforcer.py`.
+- `node >= 18` is required for the two `.mjs` hooks.
+
+The guarded wiring below checks that the hook is a readable file and that its interpreter exists, then stays quiet with exit `0` when either prerequisite is absent. A bare attempt to run `node` on a machine without Node normally exits `127`; Claude Code treats that hook failure as non-blocking, but the guard avoids the repeated stderr noise. Internal parsing, timeout, and runtime failures also fail open. Exit `2` is reserved for a genuine detection.
+
+## Install
+
+1. Clone the repository.
+
+```sh
+git clone https://github.com/caty-ai/context-kit.git
+cd context-kit
+```
+
+2. Merge each hook as its own entry in `~/.claude/settings.json` or `<project>/.claude/settings.json`. Do not replace unrelated settings.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/rm-enforcer.py\"; if [ -f \"$f\" ] && [ -r \"$f\" ] && command -v python3 >/dev/null 2>&1; then python3 -B \"$f\"; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/private-repo-enforcer.mjs\"; if [ -f \"$f\" ] && [ -r \"$f\" ] && command -v node >/dev/null 2>&1; then node \"$f\"; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/api-key-leak-detector.mjs\"; if [ -f \"$f\" ] && [ -r \"$f\" ] && command -v node >/dev/null 2>&1; then node \"$f\"; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Each hook contains its own stdin handling and runtime safety behavior. No shared `lib/` directory or launcher is required, so every hook remains independently installable.
+
+3. Replace `<CONTEXT_KIT_DIR>` with the absolute checkout path, then restart Claude Code or run `/hooks`.
+
+## Bypass Semantics
+
+For Bash hooks, Claude Code includes the shell command in `tool_input.command`. A same-line prefix is therefore visible to the hook and works for all three bypass variables:
+
+```sh
+CK_DESTRUCTIVE_OK=1 rm -rf /path-reviewed-for-deletion
+CK_PUBLIC_REPO_OK=1 gh repo create example --public
+CK_API_KEY_DETECT_DISABLED=1 printf '%s\n' 'known-false-positive'
+```
+
+The same-line form is not an environment change for the already-running hook. It works because the literal token appears in the Bash command string.
+
+Write and Edit tool calls have no Bash command string. `CK_API_KEY_DETECT_DISABLED=1` text inside file content does not bypass detection. To bypass a Write/Edit false positive, set the variable in the environment that launches Claude Code and restart it. The process-environment form also bypasses Bash detections.
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `CK_DESTRUCTIVE_OK` | Set to `1` in the hook environment, or use the literal same-line Bash token, to bypass destructive-command detection. | unset |
+| `CK_PUBLIC_REPO_OK` | Set to `1` in the hook environment, or use the literal same-line Bash token, to permit an intentional public repository operation. | unset |
+| `CK_API_KEY_DETECT_DISABLED` | Set to `1` in the hook environment to disable API-key detection; the literal same-line token also works for Bash only. | unset |
+| `CK_SCRATCH_DIR` | Directory for API-key detection evidence. A configured directory keeps its own directory permissions. | `${HOME}/.claude/scratch/${CK_AGENT:-agent}/memory` when `HOME` is set; otherwise `${TMPDIR:-/tmp}/context-kit-scratch` |
+| `CK_AGENT` | Scratch subdirectory name when `CK_SCRATCH_DIR` is unset and `HOME` is available. | `agent` |
+
+## API-Key Evidence and Exclusions
+
+On detection, the API-key hook writes a local rotation-evidence report and prints its path to stderr. The report contains the tool name, the target file path when present, provider names, and redacted matches that keep only the first eight characters. It does not store the scanned command/content or the full matched key.
+
+Evidence files are created with mode `0600`. The kit-managed default scratch root is hardened to `0700`; a user-configured `CK_SCRATCH_DIR` retains its existing directory permissions. Evidence is never written into the repository unless the operator explicitly points `CK_SCRATCH_DIR` there.
+
+Write/Edit calls targeting these intentional credential-file forms are excluded exactly as in the source hook: `.env`, `.env.<lowercase-suffix>`, `secret.json`, and `secrets.json`. The exclusion applies only when the file path ends with one of those slash-prefixed names. Bash commands are still scanned even when they mention an env file.
+
+## Verify
+
+Run the complete trio suite from the repository root:
+
+```sh
+bash tests/test_safety_hooks.sh
+```
+
+Replace `<CONTEXT_KIT_DIR>` before running the exact-wiring probes below.
+
+### rm-enforcer
+
+```sh
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/rm-enforcer.py"; if [ -f "$f" ] && [ -r "$f" ] && command -v python3 >/dev/null 2>&1; then python3 -B "$f"; fi'; echo $? # 2
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/example"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/rm-enforcer.py"; if [ -f "$f" ] && [ -r "$f" ] && command -v python3 >/dev/null 2>&1; then python3 -B "$f"; fi'; echo $? # 0
+echo '{"tool_name":"Bash","tool_input":{"command":"CK_DESTRUCTIVE_OK=1 rm -rf /"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/rm-enforcer.py"; if [ -f "$f" ] && [ -r "$f" ] && command -v python3 >/dev/null 2>&1; then python3 -B "$f"; fi'; echo $? # 0
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/rm-enforcer.py"; if [ -f "$f" ] && [ -r "$f" ] && command -v python3 >/dev/null 2>&1; then python3 -B "$f"; fi'; echo $? # 0 while the token is unreplaced
+```
+
+### private-repo-enforcer
+
+```sh
+echo '{"tool_name":"Bash","tool_input":{"command":"gh repo create example"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/private-repo-enforcer.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $? # 2
+echo '{"tool_name":"Bash","tool_input":{"command":"gh repo create example --private"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/private-repo-enforcer.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $? # 0
+echo '{"tool_name":"Bash","tool_input":{"command":"CK_PUBLIC_REPO_OK=1 gh repo create example --public"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/private-repo-enforcer.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $? # 0
+echo '{"tool_name":"Bash","tool_input":{"command":"gh repo create example"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/private-repo-enforcer.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $? # 0 while the token is unreplaced
+```
+
+### api-key-leak-detector
+
+The fake token below is intentionally non-secret but matches the preserved OpenAI regex.
+
+```sh
+echo '{"tool_name":"Bash","tool_input":{"command":"printf sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/api-key-leak-detector.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $? # 2
+echo '{"tool_name":"Bash","tool_input":{"command":"printf safe-value"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/api-key-leak-detector.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $? # 0
+echo '{"tool_name":"Bash","tool_input":{"command":"CK_API_KEY_DETECT_DISABLED=1 printf sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/api-key-leak-detector.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $? # 0
+echo '{"tool_name":"Bash","tool_input":{"command":"printf sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/api-key-leak-detector.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $? # 0 while the token is unreplaced
+```
+
+Write-tool probe through the same guarded command; it must exit `2`:
+
+```sh
+echo '{"tool_name":"Write","tool_input":{"file_path":"/tmp/example.txt","content":"sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}' | sh -c 'f="<CONTEXT_KIT_DIR>/hooks/api-key-leak-detector.mjs"; if [ -f "$f" ] && [ -r "$f" ] && command -v node >/dev/null 2>&1; then node "$f"; fi'; echo $?
+```
+
+Optional syntax and configuration checks:
+
+```sh
+bash -n tests/test_safety_hooks.sh
+python3 -B -c "import ast; ast.parse(open('hooks/rm-enforcer.py').read())"
+node --check hooks/private-repo-enforcer.mjs
+node --check hooks/api-key-leak-detector.mjs
+python3 -m json.tool examples/settings.json >/dev/null
+```

--- a/examples/settings.json
+++ b/examples/settings.json
@@ -11,6 +11,33 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/rm-enforcer.py\"; if [ -f \"$f\" ] && [ -r \"$f\" ] && command -v python3 >/dev/null 2>&1; then python3 -B \"$f\"; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/private-repo-enforcer.mjs\"; if [ -f \"$f\" ] && [ -r \"$f\" ] && command -v node >/dev/null 2>&1; then node \"$f\"; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"<CONTEXT_KIT_DIR>/hooks/api-key-leak-detector.mjs\"; if [ -f \"$f\" ] && [ -r \"$f\" ] && command -v node >/dev/null 2>&1; then node \"$f\"; fi'"
+          }
+        ]
+      },
+      {
         "matcher": "Agent|Task",
         "hooks": [
           {

--- a/hooks/api-key-leak-detector.mjs
+++ b/hooks/api-key-leak-detector.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/** Block API-key patterns in Bash, Write, and Edit tool inputs. */
+
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { join, resolve } from "path";
+
+function readStdin(timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        process.stdin.removeAllListeners();
+        process.stdin.destroy();
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    }, timeoutMs);
+
+    process.stdin.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+
+    process.stdin.on("end", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    });
+
+    process.stdin.on("error", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve("");
+      }
+    });
+
+    if (process.stdin.readableEnded && !settled) {
+      settled = true;
+      clearTimeout(timeout);
+      resolve(Buffer.concat(chunks).toString("utf-8"));
+    }
+  });
+}
+
+function resolveScratchDir() {
+  if (process.env.CK_SCRATCH_DIR) {
+    return { scratchDir: resolve(process.env.CK_SCRATCH_DIR), isDefault: false };
+  }
+
+  if (process.env.HOME) {
+    return {
+      scratchDir: resolve(
+        join(
+          process.env.HOME,
+          ".claude",
+          "scratch",
+          process.env.CK_AGENT || "agent",
+          "memory"
+        )
+      ),
+      isDefault: true,
+    };
+  }
+
+  return {
+    scratchDir: resolve(join(process.env.TMPDIR || "/tmp", "context-kit-scratch")),
+    isDefault: true,
+  };
+}
+
+// (pattern, name, description)
+const API_KEY_PATTERNS = [
+  { pattern: /sk-ant-[A-Za-z0-9\-_]{20,}/, name: "Anthropic API Key", prefix: "sk-ant-" },
+  { pattern: /sk-[A-Za-z0-9]{20,}/, name: "OpenAI API Key", prefix: "sk-" },
+  { pattern: /AIza[0-9A-Za-z_\-]{35}/, name: "Google API Key", prefix: "AIza" },
+  { pattern: /AKIA[0-9A-Z]{16}/, name: "AWS Access Key ID", prefix: "AKIA" },
+  { pattern: /glpat-[A-Za-z0-9_\-]{20,}/, name: "GitLab PAT", prefix: "glpat-" },
+  { pattern: /gh[pousr]_[A-Za-z0-9]{36,}/, name: "GitHub Token", prefix: "gh[pousr]_" },
+  { pattern: /xox[bpoars]-[A-Za-z0-9\-]{10,}/, name: "Slack Token", prefix: "xox[bpoars]-" },
+];
+
+function scanForKeys(text) {
+  if (!text || typeof text !== "string") return [];
+  const detections = [];
+  for (const { pattern, name } of API_KEY_PATTERNS) {
+    const match = pattern.exec(text);
+    if (match) {
+      const raw = match[0];
+      const redacted = raw.length > 8 ? raw.slice(0, 8) + "***[REDACTED]" : "***[REDACTED]";
+      detections.push({ name, redacted });
+    }
+  }
+  return detections;
+}
+
+function writeScratchReport(toolName, filePath, detections) {
+  try {
+    const { scratchDir, isDefault } = resolveScratchDir();
+    if (!existsSync(scratchDir)) {
+      mkdirSync(scratchDir, {
+        recursive: true,
+        ...(isDefault ? { mode: 0o700 } : {}),
+      });
+    }
+    if (isDefault) {
+      chmodSync(scratchDir, 0o700);
+    }
+
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const scratchPath = join(scratchDir, `api-key-leak-${ts}.md`);
+    const lines = [
+      "# API Key Leak Detection Report",
+      "",
+      `- **Detected at**: ${new Date().toISOString()}`,
+      `- **Tool**: ${toolName}`,
+      filePath ? `- **File**: ${filePath}` : null,
+      "",
+      "## Detected Patterns",
+      "",
+      ...detections.map((detection) => `- **${detection.name}**: \`${detection.redacted}\``),
+      "",
+      "## Action Required",
+      "",
+      "1. Remove the API key from the content immediately.",
+      "2. If the key may have been exposed, rotate it from the provider dashboard.",
+      "3. If this is a false positive, set `CK_API_KEY_DETECT_DISABLED=1` in the hook environment.",
+    ].filter((line) => line !== null);
+    writeFileSync(scratchPath, lines.join("\n") + "\n", {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    return scratchPath;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const safetyTimeout = setTimeout(() => {
+    try { process.exit(0); } catch { /* ignore */ }
+  }, 8000);
+
+  try {
+    if (process.env.CK_API_KEY_DETECT_DISABLED === "1") {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    const input = await readStdin();
+    let data = {};
+    try {
+      data = JSON.parse(input);
+    } catch {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    const toolName = data.tool_name || "";
+    const toolInput = data.tool_input || {};
+
+    if (toolName !== "Write" && toolName !== "Edit" && toolName !== "Bash") {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    if (toolName === "Bash") {
+      const cmd = toolInput.command || "";
+      if (/(?:^|[\s;])CK_API_KEY_DETECT_DISABLED=1\b/.test(cmd)) {
+        clearTimeout(safetyTimeout);
+        process.exit(0);
+      }
+    }
+
+    let textToScan = "";
+    let filePath = "";
+
+    if (toolName === "Write") {
+      textToScan = toolInput.content || "";
+      filePath = toolInput.file_path || toolInput.path || "";
+    } else if (toolName === "Edit") {
+      textToScan = toolInput.new_string || "";
+      filePath = toolInput.file_path || toolInput.path || "";
+    } else if (toolName === "Bash") {
+      textToScan = toolInput.command || "";
+    }
+
+    if (filePath && /\/(\.env|\.env\.[a-z]+|secrets?\.json)$/.test(filePath)) {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    const detections = scanForKeys(textToScan);
+    if (detections.length === 0) {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    const scratchPath = writeScratchReport(toolName, filePath, detections);
+    const detectionList = detections.map((detection) => `  - ${detection.name}: ${detection.redacted}`).join("\n");
+
+    process.stderr.write(
+      "[api-key-leak-detector] Blocked a possible API-key leak.\n"
+      + `  Detected patterns:\n${detectionList}\n`
+      + (scratchPath ? `  Local rotation evidence (mode 0600): ${scratchPath}\n` : "")
+      + "  Remove the API key from the content before trying again.\n"
+      + (toolName === "Bash"
+        ? "  For a false positive, prefix the same Bash command with CK_API_KEY_DETECT_DISABLED=1.\n"
+        : "  For a false positive, set CK_API_KEY_DETECT_DISABLED=1 in the hook environment and restart Claude Code.\n")
+    );
+
+    clearTimeout(safetyTimeout);
+    process.exit(2);
+  } catch (err) {
+    try { process.stderr.write(`[api-key-leak-detector] Error: ${err?.message || err}\n`); } catch { /* ignore */ }
+  }
+
+  clearTimeout(safetyTimeout);
+  process.exit(0);
+}
+
+process.on("uncaughtException", (err) => {
+  try { process.stderr.write(`[api-key-leak-detector] Uncaught: ${err?.message || err}\n`); } catch { /* ignore */ }
+  process.exit(0);
+});
+
+process.on("unhandledRejection", (err) => {
+  try { process.stderr.write(`[api-key-leak-detector] Rejection: ${err?.message || err}\n`); } catch { /* ignore */ }
+  process.exit(0);
+});
+
+main();

--- a/hooks/api-key-leak-detector.mjs
+++ b/hooks/api-key-leak-detector.mjs
@@ -48,7 +48,13 @@ function readStdin(timeoutMs = 2000) {
 
 function resolveScratchDir() {
   if (process.env.CK_SCRATCH_DIR) {
-    return { scratchDir: resolve(process.env.CK_SCRATCH_DIR), isDefault: false };
+    const scratchBase = process.env.HOME
+      ? join(process.env.HOME, ".claude", "scratch", process.env.CK_AGENT || "agent", "memory")
+      : join(process.env.TMPDIR || "/tmp", "context-kit-scratch");
+    return {
+      scratchDir: resolve(scratchBase, process.env.CK_SCRATCH_DIR),
+      isDefault: false,
+    };
   }
 
   if (process.env.HOME) {
@@ -156,6 +162,11 @@ async function main() {
     try {
       data = JSON.parse(input);
     } catch {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    if (data === null || typeof data !== "object" || Array.isArray(data)) {
       clearTimeout(safetyTimeout);
       process.exit(0);
     }

--- a/hooks/private-repo-enforcer.mjs
+++ b/hooks/private-repo-enforcer.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/** Require explicit private/public intent and block public GitHub repositories. */
+
+function readStdin(timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        process.stdin.removeAllListeners();
+        process.stdin.destroy();
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    }, timeoutMs);
+
+    process.stdin.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+
+    process.stdin.on("end", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    });
+
+    process.stdin.on("error", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve("");
+      }
+    });
+
+    if (process.stdin.readableEnded && !settled) {
+      settled = true;
+      clearTimeout(timeout);
+      resolve(Buffer.concat(chunks).toString("utf-8"));
+    }
+  });
+}
+
+async function main() {
+  const safetyTimeout = setTimeout(() => {
+    try { process.exit(0); } catch { /* ignore */ }
+  }, 8000);
+
+  try {
+    if (process.env.CK_PUBLIC_REPO_OK === "1") {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    const input = await readStdin();
+    let data = {};
+    try {
+      data = JSON.parse(input);
+    } catch {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    if (data.tool_name !== "Bash") {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    const cmd = (data.tool_input || {}).command || "";
+    if (!cmd || typeof cmd !== "string") {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    if (/(?:^|[\s;])CK_PUBLIC_REPO_OK=1\b/.test(cmd)) {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
+    if (/\bgh\s+repo\s+create\b/.test(cmd) && /--public\b/.test(cmd)) {
+      process.stderr.write(
+        "[private-repo-enforcer] Blocked explicit public repository creation.\n"
+        + "  This environment defaults to private repositories.\n"
+        + "  If public creation is intentional, prefix the same Bash command with CK_PUBLIC_REPO_OK=1.\n"
+        + `  Command: ${cmd}\n`
+      );
+      clearTimeout(safetyTimeout);
+      process.exit(2);
+    }
+
+    if (/\bgh\s+repo\s+create\b/.test(cmd) && !/--private\b/.test(cmd) && !/--public\b/.test(cmd)) {
+      process.stderr.write(
+        "[private-repo-enforcer] Blocked repository creation without explicit visibility.\n"
+        + "  Specify either `--private` or `--public`.\n"
+        + "  This environment defaults to `--private`.\n"
+        + `  Command: ${cmd}\n`
+      );
+      clearTimeout(safetyTimeout);
+      process.exit(2);
+    }
+
+    if (/\bgh\s+repo\s+edit\b/.test(cmd) && /--visibility\s+public\b/.test(cmd)) {
+      process.stderr.write(
+        "[private-repo-enforcer] Blocked changing a repository to public.\n"
+        + "  This environment defaults to private repositories.\n"
+        + "  If this visibility change is intentional, prefix the same Bash command with CK_PUBLIC_REPO_OK=1.\n"
+        + `  Command: ${cmd}\n`
+      );
+      clearTimeout(safetyTimeout);
+      process.exit(2);
+    }
+  } catch (err) {
+    try { process.stderr.write(`[private-repo-enforcer] Error: ${err?.message || err}\n`); } catch { /* ignore */ }
+  }
+
+  clearTimeout(safetyTimeout);
+  process.exit(0);
+}
+
+process.on("uncaughtException", (err) => {
+  try { process.stderr.write(`[private-repo-enforcer] Uncaught: ${err?.message || err}\n`); } catch { /* ignore */ }
+  process.exit(0);
+});
+
+process.on("unhandledRejection", (err) => {
+  try { process.stderr.write(`[private-repo-enforcer] Rejection: ${err?.message || err}\n`); } catch { /* ignore */ }
+  process.exit(0);
+});
+
+main();

--- a/hooks/private-repo-enforcer.mjs
+++ b/hooks/private-repo-enforcer.mjs
@@ -63,6 +63,11 @@ async function main() {
       process.exit(0);
     }
 
+    if (data === null || typeof data !== "object" || Array.isArray(data)) {
+      clearTimeout(safetyTimeout);
+      process.exit(0);
+    }
+
     if (data.tool_name !== "Bash") {
       clearTimeout(safetyTimeout);
       process.exit(0);

--- a/hooks/rm-enforcer.py
+++ b/hooks/rm-enforcer.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Block destructive Bash commands before they run."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Optional, Tuple
+
+
+DISABLED = os.environ.get("CK_DESTRUCTIVE_OK", "0") == "1"
+
+# (regex, human-readable description). First match wins.
+RISKY_PATTERNS: list[tuple[str, str]] = [
+    (r"\brm\s+-rf\s+/(?!\S)",
+     "rm -rf / would delete the root filesystem"),
+    (r"\brm\s+-rf\s+/\s",
+     "rm -rf / would delete the root filesystem"),
+    (r"\brm\s+(-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*|-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*)\s+/(?!\S|\w)",
+     "rm with recursive and force flags would delete the root filesystem"),
+    (r"\brm\s+-rf\s+~(?:\s|$)",
+     "rm -rf ~ would delete the home directory"),
+    (r"\brm\s+-rf\s+\$HOME(?:\s|$)",
+     "rm -rf $HOME would delete the home directory"),
+    (r"\bterraform\s+destroy\b",
+     "terraform destroy would destroy managed infrastructure"),
+    (r"(?i)\bdrop\s+(database|table|schema)\b",
+     "DROP DATABASE/TABLE/SCHEMA would permanently delete data"),
+    (r"\bgit\s+push\s+--force(?:-with-lease)?\s+(?:origin\s+)?(main|master)\b",
+     "git push --force to main/master could destroy repository history"),
+    (r"\bdd\s+(?:[^\s]+\s+)*if=.*\s+of=/dev/",
+     "dd output to /dev/ would overwrite a device"),
+    (r">\s*~/\.(zshrc|bashrc|zshenv|zprofile|bash_profile)\s*$",
+     "overwriting a shell startup file could break the shell environment"),
+]
+
+
+def find_risk(cmd: str) -> Optional[Tuple[str, str]]:
+    for pattern, hint in RISKY_PATTERNS:
+        if re.search(pattern, cmd):
+            return pattern, hint
+    return None
+
+
+def main() -> int:
+    try:
+        if DISABLED:
+            return 0
+
+        data = json.load(sys.stdin)
+        if not isinstance(data, dict) or data.get("tool_name") != "Bash":
+            return 0
+
+        tool_input = data.get("tool_input") or {}
+        if not isinstance(tool_input, dict):
+            return 0
+
+        cmd = tool_input.get("command", "")
+        if not cmd or not isinstance(cmd, str):
+            return 0
+
+        if re.search(r"(?:^|[\s;])CK_DESTRUCTIVE_OK=1\b", cmd):
+            return 0
+
+        risk = find_risk(cmd)
+        if risk is None:
+            return 0
+
+        _, hint = risk
+        sys.stderr.write(
+            "[rm-enforcer] Blocked a destructive command.\n"
+            f"  Reason: {hint}\n"
+            f"  Command: {cmd}\n"
+            "  If this is intentional, prefix the same Bash command with "
+            "CK_DESTRUCTIVE_OK=1.\n"
+            "  Example: CK_DESTRUCTIVE_OK=1 rm -rf /tmp/safe-to-delete\n"
+        )
+        return 2
+    except BaseException:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_safety_hooks.sh
+++ b/tests/test_safety_hooks.sh
@@ -151,6 +151,37 @@ case_rm_pattern_families() {
   record_pass "${case_name}"
 }
 
+case_rm_first_pattern_is_independently_pinned() {
+  local case_name="rm-first-pattern-independently-blocks-exact-root"
+
+  if python3 -B - "${RM_HOOK}" <<'PY'
+import io
+import json
+import runpy
+import sys
+
+namespace = runpy.run_path(sys.argv[1], run_name="rm_enforcer_test")
+first_pattern = namespace["RISKY_PATTERNS"][0]
+namespace["find_risk"].__globals__["RISKY_PATTERNS"] = [first_pattern]
+namespace["main"].__globals__["DISABLED"] = False
+
+sys.stdin = io.StringIO(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": "rm -rf /"},
+}))
+sys.stderr = io.StringIO()
+
+status = namespace["main"]()
+if status != 2 or "[rm-enforcer] Blocked a destructive command." not in sys.stderr.getvalue():
+    raise SystemExit(1)
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected pattern #1 alone to block the exact rm -rf / trigger"
+  fi
+}
+
 case_rm_allow_bypass_and_fail_open() {
   local case_name="rm-allow-bypass-and-fail-open"
 
@@ -236,6 +267,12 @@ case_private_allow_bypass_and_fail_open() {
     return
   fi
 
+  run_private 'null'
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected a null JSON body to fail open silently"
+    return
+  fi
+
   run_private "$(payload_for Write 'gh repo create example --public' '/tmp/example.txt')"
   if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
     record_pass "${case_name}"
@@ -305,7 +342,7 @@ case_api_tool_surfaces() {
 case_api_allow_bypass_exclusion_and_fail_open() {
   local case_name="api-key-allow-bypass-exclusion-and-fail-open"
   local token="sk-$(repeat_char 40 x)"
-  local personal_env='al''pha.env'
+  local provider_env="provider.env"
 
   run_api "$(payload_for Bash 'printf safe-value')"
   if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
@@ -337,17 +374,23 @@ case_api_allow_bypass_exclusion_and_fail_open() {
     return
   fi
 
-  run_api "$(payload_for Write "${token}" "/tmp/${personal_env}")"
+  run_api "$(payload_for Write "${token}" "/tmp/${provider_env}")"
   if [ "${RUN_STATUS}" != "2" ] || ! grep -Fq '[api-key-leak-detector] Blocked a possible API-key leak.' "${RUN_STDERR}"; then
-    record_fail "${case_name}" "expected the personal env filename to be scanned and blocked"
+    record_fail "${case_name}" "expected a non-excluded env filename to be scanned and blocked"
     return
   fi
 
   run_api 'garbage'
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected malformed JSON to fail open"
+    return
+  fi
+
+  run_api 'null'
   if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
     record_pass "${case_name}"
   else
-    record_fail "${case_name}" "expected malformed JSON to fail open"
+    record_fail "${case_name}" "expected a null JSON body to fail open silently"
   fi
 }
 
@@ -397,7 +440,36 @@ case_api_default_root_is_0700() {
   fi
 }
 
+case_api_relative_scratch_is_not_cwd_relative() {
+  local case_name="api-key-relative-scratch-is-not-cwd-relative"
+  local fake_home="${TMP_DIR}/relative-home"
+  local temp_cwd="${TMP_DIR}/relative-cwd"
+  local expected_dir="${fake_home}/.claude/scratch/test-agent/memory/relscratch"
+  local token="sk-$(repeat_char 40 x)"
+  local payload
+  local evidence_file
+
+  mkdir -p "${fake_home}" "${temp_cwd}"
+  payload=$(payload_for Bash "printf ${token}")
+  prepare_output_files
+  if (cd "${temp_cwd}" && printf '%s' "${payload}" | env -u CK_API_KEY_DETECT_DISABLED HOME="${fake_home}" CK_AGENT=test-agent CK_SCRATCH_DIR=relscratch node "${API_HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"); then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+  evidence_file=$(find "${expected_dir}" -type f -name 'api-key-leak-*.md' -print -quit 2>/dev/null || true)
+
+  if [ "${RUN_STATUS}" = "2" ] &&
+     [ -n "${evidence_file}" ] &&
+     [ -z "$(find "${temp_cwd}" -mindepth 1 -print -quit)" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected relative evidence under the absolute default scratch root and no files in cwd"
+  fi
+}
+
 case_rm_pattern_families
+case_rm_first_pattern_is_independently_pinned
 case_rm_allow_bypass_and_fail_open
 
 if command -v node >/dev/null 2>&1; then
@@ -408,6 +480,7 @@ if command -v node >/dev/null 2>&1; then
   case_api_allow_bypass_exclusion_and_fail_open
   case_api_evidence_permissions_and_notice
   case_api_default_root_is_0700
+  case_api_relative_scratch_is_not_cwd_relative
 else
   record_skip "private-repo-enforcer-node-cases" "node is unavailable"
   record_skip "api-key-leak-detector-node-cases" "node is unavailable"

--- a/tests/test_safety_hooks.sh
+++ b/tests/test_safety_hooks.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+RM_HOOK="${ROOT}/hooks/rm-enforcer.py"
+PRIVATE_HOOK="${ROOT}/hooks/private-repo-enforcer.mjs"
+API_HOOK="${ROOT}/hooks/api-key-leak-detector.mjs"
+TMP_DIR=$(mktemp -d)
+API_SCRATCH="${TMP_DIR}/api-scratch"
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+RUN_INDEX=0
+RUN_STDOUT=""
+RUN_STDERR=""
+RUN_STATUS=0
+
+cleanup() {
+  chmod -R u+rwx "${TMP_DIR}" 2>/dev/null || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+record_pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+record_fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+record_skip() {
+  SKIP_COUNT=$((SKIP_COUNT + 1))
+  printf 'SKIP %s: %s\n' "$1" "$2"
+}
+
+finish() {
+  printf 'SUMMARY pass=%s fail=%s skip=%s\n' "${PASS_COUNT}" "${FAIL_COUNT}" "${SKIP_COUNT}"
+  if [ "${FAIL_COUNT}" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+payload_for() {
+  local tool_name="$1"
+  local value="${2:-}"
+  local file_path="${3:-}"
+  python3 -B - "${tool_name}" "${value}" "${file_path}" <<'PY'
+import json
+import sys
+
+tool_name, value, file_path = sys.argv[1:]
+if tool_name == "Bash":
+    tool_input = {"command": value}
+elif tool_name == "Write":
+    tool_input = {"content": value, "file_path": file_path}
+elif tool_name == "Edit":
+    tool_input = {"new_string": value, "file_path": file_path}
+else:
+    tool_input = {"content": value, "file_path": file_path}
+print(json.dumps({"tool_name": tool_name, "tool_input": tool_input}))
+PY
+}
+
+prepare_output_files() {
+  RUN_INDEX=$((RUN_INDEX + 1))
+  RUN_STDOUT="${TMP_DIR}/stdout.${RUN_INDEX}"
+  RUN_STDERR="${TMP_DIR}/stderr.${RUN_INDEX}"
+}
+
+run_rm() {
+  local payload="$1"
+  shift
+  prepare_output_files
+  if printf '%s' "${payload}" | env -u CK_DESTRUCTIVE_OK "$@" python3 -B "${RM_HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+}
+
+run_private() {
+  local payload="$1"
+  shift
+  prepare_output_files
+  if printf '%s' "${payload}" | env -u CK_PUBLIC_REPO_OK "$@" node "${PRIVATE_HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+}
+
+run_api() {
+  local payload="$1"
+  shift
+  prepare_output_files
+  if printf '%s' "${payload}" | env -u CK_API_KEY_DETECT_DISABLED CK_SCRATCH_DIR="${API_SCRATCH}" "$@" node "${API_HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+}
+
+file_mode() {
+  local path="$1"
+  if stat -c '%a' "${path}" >/dev/null 2>&1; then
+    stat -c '%a' "${path}"
+  else
+    stat -f '%Lp' "${path}"
+  fi
+}
+
+repeat_char() {
+  python3 -B - "$1" "$2" <<'PY'
+import sys
+
+print(sys.argv[2] * int(sys.argv[1]), end="")
+PY
+}
+
+case_rm_pattern_families() {
+  local case_name="rm-pattern-families-block"
+  local entry
+  local label
+  local command
+  local cases=(
+    'rm-root|rm -rf /'
+    'rm-root-trailing-command|rm -rf / ; echo unreachable'
+    'rm-root-reordered-flags|rm -fr /'
+    'rm-home-tilde|rm -rf ~'
+    'rm-home-variable|rm -rf $HOME'
+    'terraform-destroy|terraform destroy -auto-approve'
+    'destructive-sql|DROP TABLE customers'
+    'forced-protected-branch|git push --force origin main'
+    'device-overwrite|dd if=/dev/zero bs=1m of=/dev/disk9'
+    'shell-rc-overwrite|echo reset > ~/.zshrc'
+  )
+
+  for entry in "${cases[@]}"; do
+    label=${entry%%|*}
+    command=${entry#*|}
+    run_rm "$(payload_for Bash "${command}")"
+    if [ "${RUN_STATUS}" != "2" ] || ! grep -Fq '[rm-enforcer] Blocked a destructive command.' "${RUN_STDERR}"; then
+      record_fail "${case_name}" "expected ${label} to exit 2 with a detection message"
+      return
+    fi
+  done
+  record_pass "${case_name}"
+}
+
+case_rm_allow_bypass_and_fail_open() {
+  local case_name="rm-allow-bypass-and-fail-open"
+
+  run_rm "$(payload_for Bash 'rm -rf /tmp/foo')"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected a scoped temporary-directory removal to pass"
+    return
+  fi
+
+  run_rm "$(payload_for Bash 'rm -rf /')" CK_DESTRUCTIVE_OK=1
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected the process-environment bypass to pass"
+    return
+  fi
+
+  run_rm "$(payload_for Bash 'CK_DESTRUCTIVE_OK=1 rm -rf /')"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected the literal same-line bypass to pass"
+    return
+  fi
+
+  run_rm 'garbage'
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected malformed JSON to fail open"
+    return
+  fi
+
+  run_rm "$(payload_for Read 'rm -rf /')"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a non-Bash tool to pass"
+  fi
+}
+
+case_private_patterns() {
+  local case_name="private-repo-three-patterns-block"
+  local entry
+  local label
+  local command
+  local cases=(
+    'create-public|gh repo create example --public'
+    'create-ambiguous|gh repo create example'
+    'edit-public|gh repo edit example --visibility public'
+  )
+
+  for entry in "${cases[@]}"; do
+    label=${entry%%|*}
+    command=${entry#*|}
+    run_private "$(payload_for Bash "${command}")"
+    if [ "${RUN_STATUS}" != "2" ] || ! grep -Fq '[private-repo-enforcer] Blocked' "${RUN_STDERR}"; then
+      record_fail "${case_name}" "expected ${label} to exit 2 with a detection message"
+      return
+    fi
+  done
+  record_pass "${case_name}"
+}
+
+case_private_allow_bypass_and_fail_open() {
+  local case_name="private-repo-allow-bypass-and-fail-open"
+
+  run_private "$(payload_for Bash 'gh repo create example --private')"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected explicit private creation to pass"
+    return
+  fi
+
+  run_private "$(payload_for Bash 'gh repo create example --public')" CK_PUBLIC_REPO_OK=1
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected the process-environment bypass to pass"
+    return
+  fi
+
+  run_private "$(payload_for Bash 'CK_PUBLIC_REPO_OK=1 gh repo create example --public')"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected the literal same-line bypass to pass"
+    return
+  fi
+
+  run_private 'garbage'
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected malformed JSON to fail open"
+    return
+  fi
+
+  run_private "$(payload_for Write 'gh repo create example --public' '/tmp/example.txt')"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a non-Bash tool to pass"
+  fi
+}
+
+case_api_pattern_families() {
+  local case_name="api-key-provider-patterns-block"
+  local anthropic="sk-ant-$(repeat_char 24 x)"
+  local openai="sk-$(repeat_char 40 x)"
+  local google="AIza$(repeat_char 35 x)"
+  local aws="AKIA$(repeat_char 16 X)"
+  local gitlab="glpat-$(repeat_char 24 x)"
+  local github="ghp_$(repeat_char 40 x)"
+  local slack="xoxb-$(repeat_char 12 x)"
+  local entry
+  local label
+  local token
+  local cases=(
+    "anthropic|${anthropic}"
+    "openai|${openai}"
+    "google|${google}"
+    "aws|${aws}"
+    "gitlab|${gitlab}"
+    "github|${github}"
+    "slack|${slack}"
+  )
+
+  for entry in "${cases[@]}"; do
+    label=${entry%%|*}
+    token=${entry#*|}
+    run_api "$(payload_for Bash "printf ${token}")"
+    if [ "${RUN_STATUS}" != "2" ] || ! grep -Fq '[api-key-leak-detector] Blocked a possible API-key leak.' "${RUN_STDERR}"; then
+      record_fail "${case_name}" "expected the format-valid fake ${label} token to be blocked"
+      return
+    fi
+  done
+  record_pass "${case_name}"
+}
+
+case_api_tool_surfaces() {
+  local case_name="api-key-write-edit-and-nontarget-surfaces"
+  local token="sk-$(repeat_char 40 x)"
+
+  run_api "$(payload_for Write "${token}" '/tmp/example.txt')"
+  if [ "${RUN_STATUS}" != "2" ]; then
+    record_fail "${case_name}" "expected Write content to be blocked"
+    return
+  fi
+
+  run_api "$(payload_for Edit "${token}" '/tmp/example.txt')"
+  if [ "${RUN_STATUS}" != "2" ]; then
+    record_fail "${case_name}" "expected Edit new_string to be blocked"
+    return
+  fi
+
+  run_api "$(payload_for Read "${token}" '/tmp/example.txt')"
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a non-target tool to pass"
+  fi
+}
+
+case_api_allow_bypass_exclusion_and_fail_open() {
+  local case_name="api-key-allow-bypass-exclusion-and-fail-open"
+  local token="sk-$(repeat_char 40 x)"
+  local personal_env='al''pha.env'
+
+  run_api "$(payload_for Bash 'printf safe-value')"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected ordinary Bash content to pass"
+    return
+  fi
+
+  run_api "$(payload_for Write "${token}" '/tmp/example.txt')" CK_API_KEY_DETECT_DISABLED=1
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected the process-environment bypass to cover Write"
+    return
+  fi
+
+  run_api "$(payload_for Bash "CK_API_KEY_DETECT_DISABLED=1 printf ${token}")"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected the literal same-line Bash bypass to pass"
+    return
+  fi
+
+  run_api "$(payload_for Write "CK_API_KEY_DETECT_DISABLED=1 ${token}" '/tmp/example.txt')"
+  if [ "${RUN_STATUS}" != "2" ]; then
+    record_fail "${case_name}" "expected bypass text inside Write content not to bypass the hook"
+    return
+  fi
+
+  run_api "$(payload_for Write "${token}" '/tmp/.env')"
+  if [ "${RUN_STATUS}" != "0" ] || [ -s "${RUN_STDERR}" ]; then
+    record_fail "${case_name}" "expected the intentional .env exclusion to pass"
+    return
+  fi
+
+  run_api "$(payload_for Write "${token}" "/tmp/${personal_env}")"
+  if [ "${RUN_STATUS}" != "2" ] || ! grep -Fq '[api-key-leak-detector] Blocked a possible API-key leak.' "${RUN_STDERR}"; then
+    record_fail "${case_name}" "expected the personal env filename to be scanned and blocked"
+    return
+  fi
+
+  run_api 'garbage'
+  if [ "${RUN_STATUS}" = "0" ] && [ ! -s "${RUN_STDERR}" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected malformed JSON to fail open"
+  fi
+}
+
+case_api_evidence_permissions_and_notice() {
+  local case_name="api-key-evidence-is-redacted-mode-0600"
+  local evidence_dir="${TMP_DIR}/evidence"
+  local token="sk-$(repeat_char 40 x)"
+  local evidence_file
+
+  mkdir -p "${evidence_dir}"
+  chmod 755 "${evidence_dir}"
+  run_api "$(payload_for Write "${token}" '/tmp/example.txt')" CK_SCRATCH_DIR="${evidence_dir}"
+  evidence_file=$(find "${evidence_dir}" -type f -name 'api-key-leak-*.md' -print -quit)
+
+  if [ "${RUN_STATUS}" = "2" ] &&
+     [ -n "${evidence_file}" ] &&
+     [ "$(file_mode "${evidence_file}")" = "600" ] &&
+     [ "$(file_mode "${evidence_dir}")" = "755" ] &&
+     grep -Fq 'Local rotation evidence (mode 0600)' "${RUN_STDERR}" &&
+     grep -Fq '***[REDACTED]' "${evidence_file}" &&
+     ! grep -Fq "${token}" "${evidence_file}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected one redacted 0600 report without changing custom directory permissions"
+  fi
+}
+
+case_api_default_root_is_0700() {
+  local case_name="api-key-default-scratch-root-is-0700"
+  local fake_home="${TMP_DIR}/home"
+  local token="sk-$(repeat_char 40 x)"
+  local payload
+  local default_dir="${fake_home}/.claude/scratch/test-agent/memory"
+
+  payload=$(payload_for Bash "printf ${token}")
+  prepare_output_files
+  if printf '%s' "${payload}" | env -u CK_API_KEY_DETECT_DISABLED -u CK_SCRATCH_DIR HOME="${fake_home}" CK_AGENT=test-agent node "${API_HOOK}" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+
+  if [ "${RUN_STATUS}" = "2" ] && [ -d "${default_dir}" ] && [ "$(file_mode "${default_dir}")" = "700" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected the kit-managed default scratch root to be mode 0700"
+  fi
+}
+
+case_rm_pattern_families
+case_rm_allow_bypass_and_fail_open
+
+if command -v node >/dev/null 2>&1; then
+  case_private_patterns
+  case_private_allow_bypass_and_fail_open
+  case_api_pattern_families
+  case_api_tool_surfaces
+  case_api_allow_bypass_exclusion_and_fail_open
+  case_api_evidence_permissions_and_notice
+  case_api_default_root_is_0700
+else
+  record_skip "private-repo-enforcer-node-cases" "node is unavailable"
+  record_skip "api-key-leak-detector-node-cases" "node is unavailable"
+fi
+
+finish


### PR DESCRIPTION
Fourth equipment (#1): the PreToolUse safety trio.

- `hooks/rm-enforcer.py` — blocks destructive commands (rm -rf variants on root/home, terraform destroy, DROP DATABASE/TABLE/SCHEMA, forced push to main/master, dd to /dev/, shell-rc overwrite). `CK_DESTRUCTIVE_OK=1` bypass (env + same-line token).
- `hooks/private-repo-enforcer.mjs` — repo creation must state visibility; blocks explicit public creation and visibility flips to public. `CK_PUBLIC_REPO_OK=1`.
- `hooks/api-key-leak-detector.mjs` — blocks Bash/Write/Edit calls carrying API-key patterns (7 providers); redacted evidence dump (0600) under the kit scratch contract; env-file exclusions preserved minus one personal env-file name (justified deviation, stronger detection). `CK_API_KEY_DETECT_DISABLED=1`.
- Inlined stdin readers (single-file installable), English-only messages, guarded wiring entries per hook, node ≥18 prerequisite + honest fail-open notes, `docs/safety-hooks.md`, suite (node cases skip cleanly).

**Implementation**: Codex GPT-5.6 Sol (high) / orchestration+commit: maintainer orchestrator
**Review seats**: GLM 5.2 + Opus 5 + Grok 4.5 (Qwen 2x down earlier today, owner-authorized fallback)

Amusing production note: while preparing this PR, the orchestrator's own live copies of these exact hooks fired three times on probe strings and PR-body text — the trio demonstrably works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
