### PR TITLE
equip-5: recall multi-layer memory search CLI (generalized)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.pyc
 .omc/
+.omx/

--- a/bin/recall
+++ b/bin/recall
@@ -8,6 +8,7 @@ import concurrent.futures
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,7 @@ DEFAULT_MEILI_COMMAND = "mem-search"
 DEFAULT_SM_ENV = "~/.config/supermemory/env"
 SCRATCH_TTL_DAYS = 7
 SM_API_URL = "https://api.supermemory.ai/v4/search"
+GREP_LINE_NUMBER_RE = re.compile(r":([0-9]+):")
 
 
 class RecallError(Exception):
@@ -341,16 +343,24 @@ def grep_search(
 
     hits: List[Dict[str, Any]] = []
     for line in result.stdout.splitlines():
-        path_text, separator, remainder = line.partition(":")
-        if not separator:
+        candidates = []
+        for match in GREP_LINE_NUMBER_RE.finditer(line):
+            path_text = line[: match.start()]
+            try:
+                path_exists = Path(path_text).exists()
+            except OSError:
+                path_exists = False
+            if path_exists:
+                candidates.append(
+                    (
+                        path_text,
+                        int(match.group(1)),
+                        line[match.end() :],
+                    )
+                )
+        if not candidates:
             continue
-        line_text, separator, text = remainder.partition(":")
-        if not separator:
-            continue
-        try:
-            line_number = int(line_text)
-        except ValueError:
-            continue
+        path_text, line_number, text = max(candidates, key=lambda item: len(item[0]))
         hits.append({"path": path_text, "line": line_number, "text": text})
         if len(hits) >= limit:
             break
@@ -366,13 +376,16 @@ def absolute_pointer_path(value: Any) -> Optional[str]:
     return os.path.abspath(str(path))
 
 
-def meili_absolute_path(value: Any) -> Optional[str]:
+def meili_absolute_path(
+    value: Any, roots: Optional[Sequence[Path]] = None
+) -> Optional[str]:
     if not value:
         return None
     path = expand_configured_path(str(value))
     if path.is_absolute():
         return os.path.abspath(str(path))
-    for root in configured_grep_roots():
+    resolved_roots = configured_grep_roots() if roots is None else roots
+    for root in resolved_roots:
         candidate = root / path
         if candidate.exists():
             return os.path.abspath(str(candidate))
@@ -423,7 +436,9 @@ def file_pointer(item: Dict[str, Any]) -> Optional[str]:
     return absolute
 
 
-def meili_pointer(item: Dict[str, Any]) -> Optional[str]:
+def meili_pointer(
+    item: Dict[str, Any], roots: Optional[Sequence[Path]] = None
+) -> Optional[str]:
     path = pick_first(
         item, ("path", "file", "filepath", "file_path", "source", "source_path")
     )
@@ -438,7 +453,7 @@ def meili_pointer(item: Dict[str, Any]) -> Optional[str]:
     )
     if path is None and is_transcript:
         return meili_transcript_pointer(item)
-    absolute = meili_absolute_path(path)
+    absolute = meili_absolute_path(path, roots)
     if not absolute:
         return None
     line = pick_first(item, ("line", "line_number", "lineNumber", "lineno"))
@@ -447,11 +462,15 @@ def meili_pointer(item: Dict[str, Any]) -> Optional[str]:
     return absolute
 
 
-def hit_pointer(layer: str, item: Dict[str, Any]) -> Optional[str]:
+def hit_pointer(
+    layer: str,
+    item: Dict[str, Any],
+    meili_roots: Optional[Sequence[Path]] = None,
+) -> Optional[str]:
     if layer == "sm":
         return sm_pointer(item)
     if layer == "meili":
-        return meili_pointer(item)
+        return meili_pointer(item, meili_roots)
     return file_pointer(item)
 
 
@@ -460,11 +479,12 @@ def emit_hits(
 ) -> Tuple[List[Dict[str, Any]], int]:
     emitted: List[Dict[str, Any]] = []
     rejected = 0
+    meili_roots = configured_grep_roots() if layer == "meili" else None
     for index, item in enumerate(raw_hits):
         if not isinstance(item, dict):
             rejected += 1
             continue
-        pointer = hit_pointer(layer, item)
+        pointer = hit_pointer(layer, item, meili_roots)
         if not pointer:
             rejected += 1
             continue
@@ -757,7 +777,9 @@ def recall(
         "scratch_path": scratch_path,
         "rejected_hits": rejected_hits,
         "stats": stats,
-        "exit_code": 0 if adapters else 1,
+        "exit_code": 0
+        if any(status["status"] == "ok" for status in statuses.values())
+        else 1,
     }
 
 
@@ -806,7 +828,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--local-only",
         action="store_true",
-        help="select only the meili and grep layers",
+        help="filter sm out of the layers selected by --layers",
     )
     parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
     parser.add_argument("--json", action="store_true", help="emit result JSON")
@@ -819,7 +841,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     try:
         if args.limit < 1:
             raise RecallError("--limit must be at least 1")
-        selected = ["meili", "grep"] if args.local_only else parse_layers(args.layers)
+        selected = parse_layers(args.layers)
+        if args.local_only:
+            selected = [layer for layer in selected if layer != "sm"]
+            if not selected:
+                raise RecallError(
+                    "--local-only removed every layer selected by --layers"
+                )
         result = recall(args.query, selected, args.limit)
     except RecallError as exc:
         parser.error(str(exc))
@@ -835,8 +863,24 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(json.dumps(printable, indent=2, sort_keys=True, ensure_ascii=False))
     else:
         print(render_human(result))
-    return int(result["exit_code"])
+    exit_code = int(result["exit_code"])
+    if exit_code:
+        print(
+            "recall: no selected layer completed; configure an available layer "
+            "or inspect the per-layer errors",
+            file=sys.stderr,
+        )
+    return exit_code
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    return_code = main()
+    try:
+        sys.stdout.flush()
+    except (BrokenPipeError, OSError):
+        return_code = 1
+    try:
+        sys.stderr.flush()
+    except (BrokenPipeError, OSError):
+        return_code = 1
+    os._exit(return_code)

--- a/bin/recall
+++ b/bin/recall
@@ -1,0 +1,842 @@
+#!/usr/bin/env python3
+"""Query configured memory layers and merge their provenance-bearing results."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+from urllib import error, request
+
+
+LAYERS = ("sm", "meili", "grep")
+DEFAULT_LIMIT = 8
+DEFAULT_TIMEOUT = 10
+OUTER_TIMEOUT_SLACK_SECONDS = 0.05
+DEFAULT_MEILI_COMMAND = "mem-search"
+DEFAULT_SM_ENV = "~/.config/supermemory/env"
+SCRATCH_TTL_DAYS = 7
+SM_API_URL = "https://api.supermemory.ai/v4/search"
+
+
+class RecallError(Exception):
+    """A user-facing error that should stop the CLI."""
+
+
+Adapter = Callable[[str, int], List[Dict[str, Any]]]
+
+
+def compact_text(value: Any, limit: int = 240) -> str:
+    if value is None:
+        return ""
+    text = " ".join(str(value).split())
+    if len(text) > limit:
+        return text[: limit - 3].rstrip() + "..."
+    return text
+
+
+def utc_z(now: Optional[datetime] = None) -> str:
+    value = now or datetime.now(timezone.utc)
+    return (
+        value.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def parse_layers(value: str) -> List[str]:
+    selected: List[str] = []
+    for item in value.split(","):
+        layer = item.strip().lower()
+        if not layer:
+            continue
+        if layer not in LAYERS:
+            raise RecallError(
+                "unknown layer {!r}; expected sm, meili, grep".format(layer)
+            )
+        if layer not in selected:
+            selected.append(layer)
+    if not selected:
+        raise RecallError("--layers must include at least one layer")
+    return selected
+
+
+def expand_configured_path(value: str) -> Path:
+    """Expand variables and HOME-backed tildes without consulting passwd."""
+    expanded = os.path.expandvars(value)
+    if expanded == "~" or expanded.startswith("~/"):
+        home = os.environ.get("HOME")
+        if home:
+            expanded = home + expanded[1:]
+    return Path(expanded)
+
+
+def default_scratch_dir() -> Path:
+    home = os.environ.get("HOME")
+    if home:
+        agent = os.environ.get("CK_AGENT") or "agent"
+        return Path(home) / ".claude" / "scratch" / agent / "memory"
+    return Path(os.environ.get("TMPDIR") or "/tmp") / "context-kit-scratch"
+
+
+def resolve_scratch_dir() -> Tuple[Path, bool]:
+    configured = os.environ.get("CK_SCRATCH_DIR")
+    if configured:
+        configured_path = expand_configured_path(configured)
+        if not configured_path.is_absolute():
+            configured_path = Path.cwd() / configured_path
+        return Path(os.path.abspath(str(configured_path))), False
+    return Path(os.path.abspath(str(default_scratch_dir()))), True
+
+
+def prepare_scratch_dir() -> Tuple[Path, bool]:
+    scratch_dir, is_default = resolve_scratch_dir()
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    if is_default:
+        scratch_dir.chmod(0o700)
+    return scratch_dir, is_default
+
+
+def default_grep_roots() -> List[Path]:
+    roots = [prepare_scratch_dir()[0]]
+    home = os.environ.get("HOME")
+    if home:
+        roots.append(Path(home) / ".claude" / "projects")
+    return roots
+
+
+def configured_grep_roots() -> List[Path]:
+    configured = os.environ.get("CK_RECALL_ROOTS")
+    raw_roots: Iterable[str]
+    if configured is None:
+        raw_roots = (str(path) for path in default_grep_roots())
+    else:
+        raw_roots = configured.split(os.pathsep)
+
+    roots: List[Path] = []
+    seen = set()
+    for value in raw_roots:
+        if not value:
+            continue
+        path = expand_configured_path(value)
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        path = Path(os.path.abspath(str(path)))
+        if not path.exists() or str(path) in seen:
+            continue
+        roots.append(path)
+        seen.add(str(path))
+    return roots
+
+
+def parse_env_file(path: Path) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return values
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        if stripped.startswith("export "):
+            stripped = stripped[7:].lstrip()
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def resolve_sm_api_key() -> Optional[str]:
+    for key_name in ("SUPERMEMORY_API_KEY", "SUPERMEMORY_CC_API_KEY"):
+        value = os.environ.get(key_name, "").strip()
+        if value:
+            return value
+
+    env_setting = os.environ.get("CK_SM_ENV", DEFAULT_SM_ENV)
+    if not env_setting:
+        return None
+    values = parse_env_file(expand_configured_path(env_setting))
+    for key_name in ("SUPERMEMORY_API_KEY", "SUPERMEMORY_CC_API_KEY"):
+        value = values.get(key_name, "").strip()
+        if value:
+            return value
+    return None
+
+
+def pick_first(data: Any, names: Sequence[str]) -> Any:
+    if isinstance(data, dict):
+        for name in names:
+            value = data.get(name)
+            if value is not None:
+                return value
+    return None
+
+
+def first_list(data: Any) -> List[Any]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("results", "hits", "items", "data", "memories", "documents"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+        nested = data.get("result")
+        if isinstance(nested, dict):
+            return first_list(nested)
+    return []
+
+
+def supermemory_search(
+    query: str, limit: int, sm_key: str, container: str
+) -> List[Dict[str, Any]]:
+    body = json.dumps(
+        {"q": query, "containerTag": container, "limit": limit}
+    ).encode("utf-8")
+    http_request = request.Request(
+        SM_API_URL,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": "Bearer {}".format(sm_key),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with request.urlopen(http_request, timeout=DEFAULT_TIMEOUT) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        raise RuntimeError("Supermemory HTTP {}".format(exc.code)) from exc
+    except error.URLError as exc:
+        detail = getattr(exc, "reason", exc)
+        raise RuntimeError("Supermemory request failed: {}".format(detail)) from exc
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Supermemory response failed: {}".format(exc)) from exc
+
+    hits: List[Dict[str, Any]] = []
+    for item in first_list(payload):
+        if isinstance(item, dict):
+            hit = dict(item)
+            hit.setdefault("containerTag", container)
+            hits.append(hit)
+    return hits[:limit]
+
+
+def meili_search(
+    query: str, limit: int, executable: str
+) -> List[Dict[str, Any]]:
+    command = [executable, "--json", "-l", str(limit), "--", query]
+    try:
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=DEFAULT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("mem-search timed out after {}s".format(DEFAULT_TIMEOUT)) from exc
+    except OSError as exc:
+        raise RuntimeError("could not run mem-search: {}".format(exc)) from exc
+    if result.returncode != 0:
+        raise RuntimeError("mem-search exited {}".format(result.returncode))
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("mem-search returned invalid JSON: {}".format(exc)) from exc
+    return [item for item in first_list(payload) if isinstance(item, dict)][:limit]
+
+
+def rg_search(
+    query: str, roots: Sequence[Path], limit: int, executable: str
+) -> List[Dict[str, Any]]:
+    command = [
+        executable,
+        "--json",
+        "-i",
+        "-m",
+        str(limit),
+        "-e",
+        query,
+        "--",
+        *[str(root) for root in roots],
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=DEFAULT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("rg timed out after {}s".format(DEFAULT_TIMEOUT)) from exc
+    except OSError as exc:
+        raise RuntimeError("could not run rg: {}".format(exc)) from exc
+    if result.returncode not in (0, 1):
+        raise RuntimeError("rg exited {}".format(result.returncode))
+
+    hits: List[Dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") != "match":
+            continue
+        data = event.get("data") or {}
+        path = (data.get("path") or {}).get("text")
+        line_number = data.get("line_number")
+        text = (data.get("lines") or {}).get("text", "")
+        hits.append({"path": path, "line": line_number, "text": text})
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+def grep_search(
+    query: str, roots: Sequence[Path], limit: int, executable: str
+) -> List[Dict[str, Any]]:
+    command = [
+        executable,
+        "-Rni",
+        "-m",
+        str(limit),
+        "-e",
+        query,
+        "--",
+        *[str(root) for root in roots],
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=DEFAULT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("grep timed out after {}s".format(DEFAULT_TIMEOUT)) from exc
+    except OSError as exc:
+        raise RuntimeError("could not run grep: {}".format(exc)) from exc
+    if result.returncode not in (0, 1):
+        raise RuntimeError("grep exited {}".format(result.returncode))
+
+    hits: List[Dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        path_text, separator, remainder = line.partition(":")
+        if not separator:
+            continue
+        line_text, separator, text = remainder.partition(":")
+        if not separator:
+            continue
+        try:
+            line_number = int(line_text)
+        except ValueError:
+            continue
+        hits.append({"path": path_text, "line": line_number, "text": text})
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+def absolute_pointer_path(value: Any) -> Optional[str]:
+    if not value:
+        return None
+    path = expand_configured_path(str(value))
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return os.path.abspath(str(path))
+
+
+def meili_absolute_path(value: Any) -> Optional[str]:
+    if not value:
+        return None
+    path = expand_configured_path(str(value))
+    if path.is_absolute():
+        return os.path.abspath(str(path))
+    for root in configured_grep_roots():
+        candidate = root / path
+        if candidate.exists():
+            return os.path.abspath(str(candidate))
+    candidate = Path.cwd() / path
+    if candidate.exists():
+        return os.path.abspath(str(candidate))
+    return None
+
+
+def meili_transcript_pointer(item: Dict[str, Any]) -> Optional[str]:
+    project = pick_first(item, ("project",))
+    session_id = pick_first(item, ("session_id", "sessionId", "session"))
+    home = os.environ.get("HOME")
+    if not home or not project or not session_id:
+        return None
+    candidate = (
+        Path(home)
+        / ".claude"
+        / "projects"
+        / str(project)
+        / "{}.jsonl".format(session_id)
+    )
+    if not candidate.exists():
+        return None
+    return "{} (session_id={})".format(candidate, session_id)
+
+
+def sm_pointer(item: Dict[str, Any]) -> Optional[str]:
+    memory_id = pick_first(item, ("id", "memoryId", "memory_id", "_id"))
+    container = pick_first(item, ("containerTag", "container_tag", "container"))
+    if not memory_id or not container:
+        return None
+    return "supermemory:{} containerTag={}".format(memory_id, container)
+
+
+def file_pointer(item: Dict[str, Any]) -> Optional[str]:
+    path = pick_first(
+        item, ("path", "file", "filepath", "file_path", "source", "source_path")
+    )
+    if isinstance(path, dict):
+        path = pick_first(path, ("text", "path", "value"))
+    absolute = absolute_pointer_path(path)
+    if not absolute:
+        return None
+    line = pick_first(item, ("line", "line_number", "lineNumber", "lineno"))
+    if line:
+        return "{}:{}".format(absolute, line)
+    return absolute
+
+
+def meili_pointer(item: Dict[str, Any]) -> Optional[str]:
+    path = pick_first(
+        item, ("path", "file", "filepath", "file_path", "source", "source_path")
+    )
+    if isinstance(path, dict):
+        path = pick_first(path, ("text", "path", "value"))
+    index = pick_first(item, ("_index", "index"))
+    is_transcript = (
+        index is not None and "transcript" in str(index).lower()
+    ) or (
+        path is None
+        and pick_first(item, ("session_id", "sessionId", "session")) is not None
+    )
+    if path is None and is_transcript:
+        return meili_transcript_pointer(item)
+    absolute = meili_absolute_path(path)
+    if not absolute:
+        return None
+    line = pick_first(item, ("line", "line_number", "lineNumber", "lineno"))
+    if line:
+        return "{}:{}".format(absolute, line)
+    return absolute
+
+
+def hit_pointer(layer: str, item: Dict[str, Any]) -> Optional[str]:
+    if layer == "sm":
+        return sm_pointer(item)
+    if layer == "meili":
+        return meili_pointer(item)
+    return file_pointer(item)
+
+
+def emit_hits(
+    layer: str, raw_hits: Sequence[Dict[str, Any]]
+) -> Tuple[List[Dict[str, Any]], int]:
+    emitted: List[Dict[str, Any]] = []
+    rejected = 0
+    for index, item in enumerate(raw_hits):
+        if not isinstance(item, dict):
+            rejected += 1
+            continue
+        pointer = hit_pointer(layer, item)
+        if not pointer:
+            rejected += 1
+            continue
+        title = compact_text(
+            pick_first(item, ("title", "name", "heading", "path", "file"))
+        ) or pointer
+        snippet = compact_text(
+            pick_first(
+                item,
+                ("snippet", "text", "content", "body", "summary", "description"),
+            )
+        )
+        emitted.append(
+            {
+                "layer": layer,
+                "pointer": pointer,
+                "title": title,
+                "snippet": snippet,
+                "ordinal": index,
+            }
+        )
+    return emitted, rejected
+
+
+def round_robin(
+    layer_hits: Dict[str, List[Dict[str, Any]]], layer_order: Sequence[str]
+) -> List[Dict[str, Any]]:
+    merged: List[Dict[str, Any]] = []
+    index = 0
+    while True:
+        added = False
+        for layer in layer_order:
+            hits = layer_hits.get(layer, [])
+            if index < len(hits):
+                merged.append(hits[index])
+                added = True
+        if not added:
+            return merged
+        index += 1
+
+
+def status_entry(
+    status: str, reason: str, hits: int = 0, latency_ms: int = 0
+) -> Dict[str, Any]:
+    return {
+        "status": status,
+        "reason": compact_text(reason, 160),
+        "hits": hits,
+        "latency_ms": int(latency_ms),
+    }
+
+
+def build_layer_plans(
+    selected: Sequence[str],
+) -> Tuple[Dict[str, Adapter], Dict[str, str]]:
+    adapters: Dict[str, Adapter] = {}
+    skips: Dict[str, str] = {}
+
+    if "sm" in selected:
+        container = os.environ.get("CK_SM_CONTAINER", "").strip()
+        sm_key = resolve_sm_api_key()
+        if not container and not sm_key:
+            skips["sm"] = (
+                "CK_SM_CONTAINER and SUPERMEMORY_API_KEY are not configured"
+            )
+        elif not container:
+            skips["sm"] = "CK_SM_CONTAINER is not configured"
+        elif not sm_key:
+            skips["sm"] = "SUPERMEMORY_API_KEY is not configured"
+        else:
+            adapters["sm"] = lambda query, limit: supermemory_search(
+                query, limit, sm_key, container
+            )
+
+    if "meili" in selected:
+        command_name = os.environ.get(
+            "CK_RECALL_MEILI_CMD", DEFAULT_MEILI_COMMAND
+        ).strip()
+        expanded_command = (
+            str(expand_configured_path(command_name)) if command_name else ""
+        )
+        executable = shutil.which(expanded_command) if expanded_command else None
+        if not executable:
+            skips["meili"] = "mem-search command is unavailable"
+        else:
+            adapters["meili"] = lambda query, limit: meili_search(
+                query, limit, executable
+            )
+
+    if "grep" in selected:
+        roots = configured_grep_roots()
+        if not roots:
+            skips["grep"] = "no roots"
+        else:
+            rg_executable = shutil.which("rg")
+            grep_executable = shutil.which("grep")
+            if rg_executable:
+                adapters["grep"] = lambda query, limit: rg_search(
+                    query, roots, limit, rg_executable
+                )
+            elif grep_executable:
+                adapters["grep"] = lambda query, limit: grep_search(
+                    query, roots, limit, grep_executable
+                )
+            else:
+                skips["grep"] = "neither rg nor grep is available"
+
+    return adapters, skips
+
+
+def run_layer(
+    layer: str, adapter: Adapter, query: str, limit: int
+) -> Tuple[List[Dict[str, Any]], int, int]:
+    started = time.monotonic()
+    raw_hits = adapter(query, limit)
+    latency_ms = int((time.monotonic() - started) * 1000)
+    hits, rejected = emit_hits(layer, raw_hits)
+    return hits, rejected, latency_ms
+
+
+def reserve_result_file(scratch_dir: Path, timestamp: str) -> Tuple[Path, int]:
+    base = "recall-{}".format(timestamp.replace(":", "-"))
+    for attempt in range(1024):
+        suffix = "" if attempt == 0 else "-{}-{}".format(os.getpid(), attempt)
+        path = scratch_dir / "{}{}.md".format(base, suffix)
+        try:
+            descriptor = os.open(
+                str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600
+            )
+            return path, descriptor
+        except FileExistsError:
+            continue
+    raise OSError("could not reserve a unique recall result file")
+
+
+def render_result_dump(
+    query: str,
+    timestamp: str,
+    expires_at: str,
+    selected: Sequence[str],
+    statuses: Dict[str, Dict[str, Any]],
+    hits: Sequence[Dict[str, Any]],
+) -> str:
+    lines = [
+        "---",
+        "type: scratch",
+        "mode: proactive-recall",
+        "createdAt: {}".format(timestamp),
+        "expiresAt: {}".format(expires_at),
+        "---",
+        "",
+        "# Recall {}".format(timestamp),
+        "",
+        "Query: `{}`".format(query.replace("`", "\\`")),
+        "",
+    ]
+    for layer in selected:
+        status = statuses[layer]
+        lines.append(
+            "- layer={} status={} hits={} latency_ms={} reason={}".format(
+                layer,
+                status["status"],
+                status["hits"],
+                status["latency_ms"],
+                status["reason"],
+            )
+        )
+    lines.append("")
+    for hit in hits:
+        lines.extend(
+            (
+                "## [{}] {}".format(hit["layer"], hit["title"]),
+                "pointer: {}".format(hit["pointer"]),
+                "",
+            )
+        )
+        if hit["snippet"]:
+            lines.extend((hit["snippet"], ""))
+    return "\n".join(lines)
+
+
+def write_result_dump(
+    query: str,
+    timestamp: str,
+    expires_at: str,
+    selected: Sequence[str],
+    statuses: Dict[str, Dict[str, Any]],
+    hits: Sequence[Dict[str, Any]],
+) -> str:
+    scratch_dir, _ = prepare_scratch_dir()
+    path, descriptor = reserve_result_file(scratch_dir, timestamp)
+    content = render_result_dump(
+        query, timestamp, expires_at, selected, statuses, hits
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(content)
+    except BaseException:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+    return str(path)
+
+
+def recall(
+    query: str,
+    selected: Sequence[str],
+    limit: int,
+    now: Optional[datetime] = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Dict[str, Any]:
+    adapters, skips = build_layer_plans(selected)
+    statuses = {
+        layer: status_entry("skip", skips[layer])
+        for layer in selected
+        if layer in skips
+    }
+    layer_hits: Dict[str, List[Dict[str, Any]]] = {
+        layer: [] for layer in selected
+    }
+    rejected_hits = 0
+
+    if adapters:
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=len(adapters))
+        futures = {}
+        starts = {}
+        try:
+            for layer in selected:
+                adapter = adapters.get(layer)
+                if adapter is None:
+                    continue
+                starts[layer] = time.monotonic()
+                future = executor.submit(run_layer, layer, adapter, query, limit)
+                futures[future] = layer
+            done, not_done = concurrent.futures.wait(
+                futures, timeout=timeout + OUTER_TIMEOUT_SLACK_SECONDS
+            )
+            for future in done:
+                layer = futures[future]
+                try:
+                    hits, rejected, latency_ms = future.result()
+                except Exception as exc:
+                    latency_ms = int(
+                        (time.monotonic() - starts[layer]) * 1000
+                    )
+                    statuses[layer] = status_entry(
+                        "error", str(exc) or exc.__class__.__name__, 0, latency_ms
+                    )
+                    continue
+                layer_hits[layer] = hits
+                rejected_hits += rejected
+                statuses[layer] = status_entry(
+                    "ok", "completed", len(hits), latency_ms
+                )
+            for future in not_done:
+                layer = futures[future]
+                latency_ms = int((time.monotonic() - starts[layer]) * 1000)
+                statuses[layer] = status_entry(
+                    "error",
+                    "timeout after {:g}s".format(timeout),
+                    0,
+                    latency_ms,
+                )
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+
+    merged_hits = round_robin(layer_hits, selected)
+    moment = now or datetime.now(timezone.utc)
+    timestamp = utc_z(moment)
+    expires_at = utc_z(moment + timedelta(days=SCRATCH_TTL_DAYS))
+    scratch_path = write_result_dump(
+        query, timestamp, expires_at, selected, statuses, merged_hits
+    )
+    stats = {
+        "ts": timestamp,
+        "query_sha256": hashlib.sha256(query.encode("utf-8")).hexdigest()[:12],
+        "layers_queried": list(selected),
+        "per_layer": statuses,
+        "sm_queried": "sm" in adapters,
+        "rejected_hits": rejected_hits,
+    }
+    return {
+        "ts": timestamp,
+        "layers_queried": list(selected),
+        "per_layer": statuses,
+        "hits": merged_hits,
+        "top_hits": merged_hits[:limit],
+        "scratch_path": scratch_path,
+        "rejected_hits": rejected_hits,
+        "stats": stats,
+        "exit_code": 0 if adapters else 1,
+    }
+
+
+def render_human(result: Dict[str, Any]) -> str:
+    lines = []
+    for layer in result["layers_queried"]:
+        status = result["per_layer"][layer]
+        lines.append(
+            "layer={} status={} hits={} latency_ms={} reason={}".format(
+                layer,
+                status["status"],
+                status["hits"],
+                status["latency_ms"],
+                status["reason"],
+            )
+        )
+    lines.append(
+        "stats rejected_hits={} scratch={}".format(
+            result["rejected_hits"], result["scratch_path"]
+        )
+    )
+    lines.append("")
+    for hit in result["top_hits"]:
+        snippet = " | {}".format(hit["snippet"]) if hit["snippet"] else ""
+        lines.append(
+            "- [{}] {} | {}{}".format(
+                hit["layer"], hit["pointer"], hit["title"], snippet
+            )
+        )
+    if not result["top_hits"]:
+        lines.append("- no hits")
+    lines.extend(("", "scratch: {}".format(result["scratch_path"])))
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="recall", description="Query configured memory recall layers."
+    )
+    parser.add_argument("query", help="search expression")
+    parser.add_argument(
+        "--layers",
+        default=",".join(LAYERS),
+        help="comma-separated layers: sm,meili,grep",
+    )
+    parser.add_argument(
+        "--local-only",
+        action="store_true",
+        help="select only the meili and grep layers",
+    )
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument("--json", action="store_true", help="emit result JSON")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.limit < 1:
+            raise RecallError("--limit must be at least 1")
+        selected = ["meili", "grep"] if args.local_only else parse_layers(args.layers)
+        result = recall(args.query, selected, args.limit)
+    except RecallError as exc:
+        parser.error(str(exc))
+    except Exception as exc:
+        print(
+            "recall: unexpected failure: {}".format(str(exc) or exc.__class__.__name__),
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.json:
+        printable = {key: value for key, value in result.items() if key != "exit_code"}
+        print(json.dumps(printable, indent=2, sort_keys=True, ensure_ascii=False))
+    else:
+        print(render_human(result))
+    return int(result["exit_code"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -22,7 +22,7 @@ All three layers are selected by default, but optional integrations are never as
 - missing `mem-search`: `meili` reports `status=skip` without starting a subprocess;
 - an explicit `CK_RECALL_ROOTS` value that contains no existing roots: `grep` reports `status=skip reason=no roots`.
 
-Every selected layer always emits one `ok`, `skip`, or `error` status with a reason. An error in one layer does not cancel the other layers. If at least one selected layer was runnable and attempted, the command exits `0`, even when that attempted layer reports an error. A selection containing only unavailable layers exits nonzero after printing its skip statuses and writing the result dump.
+Every selected layer always emits one `ok`, `skip`, or `error` status with a reason. An error in one layer does not cancel the other layers. The command exits `0` when at least one attempted layer completes with `status=ok`, including a successful zero-hit search. It exits `1` when every attempted layer errors or when no selected layer can be attempted; skipped layers do not count as attempts. Nonzero runs write configuration/error guidance to stderr so stdout remains machine-readable.
 
 ## Prerequisites
 
@@ -63,7 +63,7 @@ recall "release decision" --layers grep --limit 5
 recall "release decision" --layers meili,grep --json
 ```
 
-`--local-only` maps directly to `meili,grep` and therefore takes precedence over `--layers` when both are supplied. Repeated layer names are de-duplicated while preserving their first position. The grep query keeps the source command's regular-expression behavior.
+`--local-only` filters `sm` out of the layer set selected by `--layers`; it does not reset that selection. Thus the default becomes `meili,grep`, while `--layers grep --local-only` remains grep-only. A selection that contains only `sm` becomes invalid after filtering. Repeated layer names are de-duplicated while preserving their first position. The grep query keeps the source command's regular-expression behavior.
 
 ## Layer setup
 
@@ -86,6 +86,8 @@ export CK_SM_CONTAINER="my-memory-container"
 ```
 
 The compatibility name `SUPERMEMORY_CC_API_KEY` is also accepted directly and in the env file. The env file is parsed as simple `KEY=VALUE` or `export KEY=VALUE` lines; it is never sourced as shell code. There is deliberately no default container.
+
+Warning: the standard-library HTTP client follows redirects and can forward the bearer token to a redirected host. Keep the default Supermemory API host pinned unless you trust the complete redirect chain.
 
 ### Meili / `mem-search` (`meili`)
 
@@ -159,11 +161,11 @@ It then prints the rejected-hit count and scratch path, followed by up to `--lim
 
 Hits are merged round-robin in selected-layer order before the final top limit is applied. Supermemory pointers contain the memory ID and configured container tag; local and Meili pointers are absolute file paths, with line numbers when supplied. Hits without usable provenance are rejected rather than emitted.
 
-`--json` preserves the same information under `layers_queried`, `per_layer`, `hits`, `top_hits`, `scratch_path`, `rejected_hits`, and `stats`. Each selected `per_layer` entry always includes `status`, `reason`, `hits`, and `latency_ms`. The `hits` array contains the full round-robin merge; `top_hits` contains the final bounded view.
+`--json` preserves the same information under `layers_queried`, `per_layer`, `hits`, `top_hits`, `scratch_path`, `rejected_hits`, and `stats`. Each selected `per_layer` entry always includes `status`, `reason`, `hits`, and `latency_ms`. The `hits` array contains the full round-robin merge; `top_hits` contains the final bounded view. The personal source tool's separate stats-JSONL sink was intentionally omitted from this public kit; stats remain in the command result and scratch dump.
 
 Every invocation that passes argument validation writes a complete Markdown dump named `recall-*.md` through the kit scratch contract. Its frontmatter includes `createdAt` and `expiresAt` with the kit's seven-day scratch TTL; cleanup remains user-owned. A whole-command failure, such as an unwritable result directory, prints a clear English `recall: unexpected failure: ...` message to stderr and exits nonzero.
 
-Each adapter has its own ten-second timeout. The parallel fan-out also has a ten-second outer deadline with a small scheduling allowance; unfinished layers report `status=error reason=timeout after 10s` without delaying result assembly further.
+Each adapter has its own ten-second timeout. The parallel fan-out also has a ten-second outer deadline with a small scheduling allowance; unfinished layers report `status=error reason=timeout after 10s` without delaying result assembly. After flushing stdout and stderr, the CLI hard-exits with its result code, so a stuck layer thread cannot keep the process alive beyond the outer deadline plus normal output overhead.
 
 ## Verify
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -1,0 +1,199 @@
+# recall
+
+## What/Why
+
+`recall` searches up to three memory layers in parallel and returns one bounded, provenance-bearing result list:
+
+- `sm` queries a configured Supermemory container.
+- `meili` delegates to a compatible `mem-search` command.
+- `grep` searches configured local roots with `rg`, falling back to `grep`.
+
+The command is intended for an individual agent's context-recovery workflow.
+
+## Individual recall and shared FMA
+
+`recall` complements, but does not install or replace, the shared-memory architecture described by [`caty-ai/family-memory-architecture`](https://github.com/caty-ai/family-memory-architecture). `context-kit` supplies the individual recall client; the linked FMA project describes the shared family-memory relationship and operating model. A local-only setup works without the shared system.
+
+## Degrade by default
+
+All three layers are selected by default, but optional integrations are never assumed. Before starting work, `recall` checks each selected layer:
+
+- missing Supermemory credentials or container: `sm` reports `status=skip` without making a network request;
+- missing `mem-search`: `meili` reports `status=skip` without starting a subprocess;
+- an explicit `CK_RECALL_ROOTS` value that contains no existing roots: `grep` reports `status=skip reason=no roots`.
+
+Every selected layer always emits one `ok`, `skip`, or `error` status with a reason. An error in one layer does not cancel the other layers. If at least one selected layer was runnable and attempted, the command exits `0`, even when that attempted layer reports an error. A selection containing only unavailable layers exits nonzero after printing its skip statuses and writing the result dump.
+
+## Prerequisites
+
+- Python 3.9 or newer.
+- No Python packages are required; `bin/recall` uses only the standard library.
+- `rg` is preferred for local search. POSIX `grep` is used when `rg` is absent.
+
+## Install
+
+Clone the repository and add its `bin` directory to `PATH`, or copy `bin/recall` to a directory already on `PATH`.
+
+```sh
+git clone https://github.com/caty-ai/context-kit.git
+cd context-kit
+export PATH="$PWD/bin:$PATH"
+```
+
+`recall` is a CLI, not a Claude Code hook. It requires no `settings.json` wiring.
+
+## Usage
+
+Search every configured layer:
+
+```sh
+recall "release decision"
+```
+
+Search only the local layers (`meili,grep`):
+
+```sh
+recall "release decision" --local-only
+```
+
+Select layers explicitly, cap the merged output, or request machine-readable output:
+
+```sh
+recall "release decision" --layers grep --limit 5
+recall "release decision" --layers meili,grep --json
+```
+
+`--local-only` maps directly to `meili,grep` and therefore takes precedence over `--layers` when both are supplied. Repeated layer names are de-duplicated while preserving their first position. The grep query keeps the source command's regular-expression behavior.
+
+## Layer setup
+
+### Supermemory (`sm`)
+
+Both a nonempty container and API key are required:
+
+```sh
+export CK_SM_CONTAINER="my-memory-container"
+export SUPERMEMORY_API_KEY="<key>"
+recall "onboarding" --layers sm
+```
+
+Instead of exporting the key directly, store it in `${HOME}/.config/supermemory/env` or point `CK_SM_ENV` to another env file:
+
+```sh
+printf 'SUPERMEMORY_API_KEY=%s\n' '<key>' > /secure/path/supermemory.env
+export CK_SM_ENV=/secure/path/supermemory.env
+export CK_SM_CONTAINER="my-memory-container"
+```
+
+The compatibility name `SUPERMEMORY_CC_API_KEY` is also accepted directly and in the env file. The env file is parsed as simple `KEY=VALUE` or `export KEY=VALUE` lines; it is never sourced as shell code. There is deliberately no default container.
+
+### Meili / `mem-search` (`meili`)
+
+By default, `mem-search` must resolve through `PATH`. Override the executable name or path with `CK_RECALL_MEILI_CMD`:
+
+```sh
+export CK_RECALL_MEILI_CMD=/opt/memory/bin/mem-search
+recall "onboarding" --layers meili
+```
+
+Environment variables and a HOME-backed `~` in `CK_RECALL_MEILI_CMD` are expanded before executable lookup, so values such as `~/bin/mem-search` are supported.
+
+The subprocess contract is stable:
+
+```text
+<resolved-command> --json -l <LIMIT> -- <QUERY>
+```
+
+Its stdout must be JSON. A top-level list, or an object containing a list under `results`, `hits`, `items`, `data`, `memories`, or `documents`, is accepted.
+
+Absolute file paths are emitted directly. Relative file paths must resolve beneath an existing `CK_RECALL_ROOTS` entry (or the current directory) before they are emitted. Transcript results that provide `project` and `session_id` without a path resolve to an existing `${HOME}/.claude/projects/<project>/<session_id>.jsonl`, matching the source tool's provenance behavior.
+
+### Local search (`grep`)
+
+Set `CK_RECALL_ROOTS` to a colon-separated list on macOS and Linux (`os.pathsep` is used):
+
+```sh
+export CK_RECALL_ROOTS="/path/to/private-memory:/path/to/project-notes"
+recall "onboarding" --layers grep
+```
+
+Nonexistent entries are silently removed. If `CK_RECALL_ROOTS` is unset, the defaults are:
+
+1. `CK_SCRATCH_DIR`, or `${HOME}/.claude/scratch/${CK_AGENT:-agent}/memory` when `HOME` is set, otherwise `${TMPDIR:-/tmp}/context-kit-scratch`;
+2. `${HOME}/.claude/projects`, when it exists.
+
+The kit scratch root is prepared before default-root preflight because the validated invocation writes its result there. Consequently, a clean-machine default `grep` layer is runnable with zero hits rather than skipped. Only an explicit empty or all-missing `CK_RECALL_ROOTS` produces `status=skip reason=no roots`.
+
+An explicitly empty `CK_RECALL_ROOTS` selects zero roots and produces `status=skip reason=no roots`.
+
+## Environment variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `SUPERMEMORY_API_KEY` | Preferred Supermemory API key, read directly before any env file. | unset |
+| `SUPERMEMORY_CC_API_KEY` | Compatibility API-key name from the source tool. | unset |
+| `CK_SM_ENV` | File containing either accepted API-key name. | `${HOME}/.config/supermemory/env` |
+| `CK_SM_CONTAINER` | Supermemory `containerTag`; required and intentionally has no personal default. | unset |
+| `CK_RECALL_MEILI_CMD` | Executable resolved through `PATH`, or an executable path. | `mem-search` |
+| `CK_RECALL_ROOTS` | Local search roots separated by the platform path separator. Empty means no roots. | kit scratch memory root plus existing `${HOME}/.claude/projects` |
+| `CK_SCRATCH_DIR` | Directory receiving the complete recall result dump and the first default grep root. | `${HOME}/.claude/scratch/${CK_AGENT:-agent}/memory`, or `${TMPDIR:-/tmp}/context-kit-scratch` without `HOME` |
+| `CK_AGENT` | Agent name used in the default scratch path. | `agent` |
+
+Direct environment values take precedence over `CK_SM_ENV`. A configured `CK_SCRATCH_DIR` keeps its existing directory permissions. The kit-created default scratch directory is mode `0700`, and result files are mode `0600`.
+
+Environment variables and a HOME-backed `~` in `CK_SCRATCH_DIR` are expanded. Relative configured paths remain relative to the process working directory. Because any explicit scratch directory is user-owned, `recall` does not change its directory mode.
+
+## Stable output contract
+
+Human output begins with one line per selected layer, in selection order:
+
+```text
+layer=<sm|meili|grep> status=<ok|skip|error> hits=<N> latency_ms=<N> reason=<text>
+```
+
+It then prints the rejected-hit count and scratch path, followed by up to `--limit` merged hits:
+
+```text
+- [<layer>] <provenance-pointer> | <title> | <snippet>
+```
+
+Hits are merged round-robin in selected-layer order before the final top limit is applied. Supermemory pointers contain the memory ID and configured container tag; local and Meili pointers are absolute file paths, with line numbers when supplied. Hits without usable provenance are rejected rather than emitted.
+
+`--json` preserves the same information under `layers_queried`, `per_layer`, `hits`, `top_hits`, `scratch_path`, `rejected_hits`, and `stats`. Each selected `per_layer` entry always includes `status`, `reason`, `hits`, and `latency_ms`. The `hits` array contains the full round-robin merge; `top_hits` contains the final bounded view.
+
+Every invocation that passes argument validation writes a complete Markdown dump named `recall-*.md` through the kit scratch contract. Its frontmatter includes `createdAt` and `expiresAt` with the kit's seven-day scratch TTL; cleanup remains user-owned. A whole-command failure, such as an unwritable result directory, prints a clear English `recall: unexpected failure: ...` message to stderr and exits nonzero.
+
+Each adapter has its own ten-second timeout. The parallel fan-out also has a ten-second outer deadline with a small scheduling allowance; unfinished layers report `status=error reason=timeout after 10s` without delaying result assembly further.
+
+## Verify
+
+Run the temp-only self-check from the repository root:
+
+```sh
+bash tests/test_recall.sh
+```
+
+Local-search one-liner:
+
+```sh
+d=$(mktemp -d); printf 'recall-probe\n' > "$d/note.md"; CK_RECALL_ROOTS="$d" CK_SCRATCH_DIR="$d/out" bin/recall recall-probe --layers grep; rm -rf "$d"
+```
+
+Default degradation one-liner: unconfigured `sm` and `meili` print skip lines while the seeded `grep` root succeeds.
+
+```sh
+d=$(mktemp -d); mkdir -p "$d/root"; printf 'recall-probe\n' > "$d/root/note.md"; env -u SUPERMEMORY_API_KEY -u SUPERMEMORY_CC_API_KEY CK_SM_ENV="$d/missing" CK_SM_CONTAINER= CK_RECALL_MEILI_CMD=context-kit-missing-mem-search CK_RECALL_ROOTS="$d/root" CK_SCRATCH_DIR="$d/out" bin/recall recall-probe; rm -rf "$d"
+```
+
+Degraded explicit-selection one-liner (expected exit is nonzero):
+
+```sh
+d=$(mktemp -d); env -u SUPERMEMORY_API_KEY -u SUPERMEMORY_CC_API_KEY CK_SM_ENV="$d/missing" CK_SM_CONTAINER= CK_SCRATCH_DIR="$d/out" bin/recall probe --layers sm; test $? -ne 0; rm -rf "$d"
+```
+
+Syntax and bytecode-cleanliness checks:
+
+```sh
+python3 -B -c "import ast; ast.parse(open('bin/recall', encoding='utf-8').read())"
+test ! -e bin/__pycache__
+```

--- a/tests/test_recall.sh
+++ b/tests/test_recall.sh
@@ -171,29 +171,28 @@ case_nonexistent_roots_are_dropped() {
   fi
 }
 
-case_local_only_maps_exactly() {
-  local case_name="local-only-maps-exactly"
+case_local_only_filters_selected_layers() {
+  local case_name="local-only-filters-selected-layers"
   local root="${TMP_DIR}/local-root"
   mkdir -p "${root}"
   printf 'local-map-probe\n' > "${root}/local.md"
   run_clean "${TMP_DIR}/local-scratch" env CK_RECALL_ROOTS="${root}" \
-    "${RECALL}" local-map-probe --layers sm --local-only --json
+    "${RECALL}" local-map-probe --layers grep --local-only --json
   if [ "${RUN_STATUS}" = "0" ] && python3 - "${RUN_STDOUT}" <<'PY'
 import json
 import sys
 
 with open(sys.argv[1], encoding="utf-8") as handle:
     result = json.load(handle)
-assert result["layers_queried"] == ["meili", "grep"]
-assert list(result["per_layer"]) == ["grep", "meili"] or set(result["per_layer"]) == {"meili", "grep"}
-assert result["per_layer"]["meili"]["status"] == "skip"
+assert result["layers_queried"] == ["grep"]
+assert list(result["per_layer"]) == ["grep"]
 assert result["per_layer"]["grep"]["status"] == "ok"
 assert all("reason" in item for item in result["per_layer"].values())
 PY
   then
     record_pass "${case_name}"
   else
-    record_fail "${case_name}" "--local-only should select meili,grep regardless of --layers"
+    record_fail "${case_name}" "--local-only should remove sm without resetting --layers"
   fi
 }
 
@@ -252,8 +251,8 @@ PY
   fi
 }
 
-case_runnable_error_is_fail_soft() {
-  local case_name="runnable-error-is-fail-soft"
+case_all_attempted_errors_exit_nonzero_with_stderr_guidance() {
+  local case_name="all-attempted-errors-exit-nonzero-with-stderr-guidance"
   local fake_meili="${TMP_DIR}/bad-mem-search"
   cat > "${fake_meili}" <<'SH'
 #!/bin/sh
@@ -262,13 +261,54 @@ SH
   chmod +x "${fake_meili}"
 
   run_clean "${TMP_DIR}/error-scratch" env CK_RECALL_MEILI_CMD="${fake_meili}" \
-    "${RECALL}" probe --layers meili
+    "${RECALL}" probe --layers meili --json
+  if [ "${RUN_STATUS}" = "1" ] &&
+     python3 - "${RUN_STDOUT}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    result = json.load(handle)
+status = result["per_layer"]["meili"]
+assert status["status"] == "error"
+assert status["hits"] == 0
+assert status["reason"].startswith("mem-search returned invalid JSON:")
+PY
+  then
+    if ! grep -Fq 'no selected layer completed' "${RUN_STDOUT}" &&
+       grep -Fq 'recall: no selected layer completed' "${RUN_STDERR}"; then
+      record_pass "${case_name}"
+    else
+      record_fail "${case_name}" "all-error JSON must keep guidance on stderr"
+    fi
+  else
+    record_fail "${case_name}" "all attempted errors should exit 1 and keep guidance on stderr"
+  fi
+}
+
+case_layer_error_isolated_from_success() {
+  local case_name="layer-error-isolated-from-success"
+  local root="${TMP_DIR}/isolation-root"
+  local fake_meili="${TMP_DIR}/isolation-bad-mem-search"
+  mkdir -p "${root}"
+  printf 'isolation-probe\n' > "${root}/memory.md"
+  cat > "${fake_meili}" <<'SH'
+#!/bin/sh
+printf 'not-json\n'
+SH
+  chmod +x "${fake_meili}"
+
+  run_clean "${TMP_DIR}/isolation-scratch" env \
+    CK_RECALL_ROOTS="${root}" CK_RECALL_MEILI_CMD="${fake_meili}" \
+    "${RECALL}" isolation-probe --layers meili,grep
   if [ "${RUN_STATUS}" = "0" ] &&
      grep -Fq 'layer=meili status=error hits=0' "${RUN_STDOUT}" &&
-     grep -Fq 'reason=mem-search returned invalid JSON:' "${RUN_STDOUT}"; then
+     grep -Fq 'layer=grep status=ok hits=1' "${RUN_STDOUT}" &&
+     grep -Fq "[grep] ${root}/memory.md:1" "${RUN_STDOUT}" &&
+     ! grep -Fq 'no selected layer completed' "${RUN_STDERR}"; then
     record_pass "${case_name}"
   else
-    record_fail "${case_name}" "a runnable layer error should be reported but still exit 0"
+    record_fail "${case_name}" "one layer error must not cancel or fail a successful layer"
   fi
 }
 
@@ -298,7 +338,7 @@ started = time.monotonic()
 result = module.recall("probe", ["grep"], 1, timeout=0.01)
 elapsed = time.monotonic() - started
 assert elapsed < 0.15, elapsed
-assert result["exit_code"] == 0
+assert result["exit_code"] == 1
 assert result["per_layer"]["grep"]["status"] == "error"
 assert result["per_layer"]["grep"]["reason"] == "timeout after 0.01s"
 PY
@@ -306,6 +346,81 @@ PY
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "outer future deadline should return a timeout result without awaiting a slow adapter"
+  fi
+}
+
+case_cli_process_honors_outer_deadline() {
+  local case_name="cli-process-honors-outer-deadline"
+  local fake_meili="${TMP_DIR}/stuck-mem-search"
+  local site_dir="${TMP_DIR}/deadline-pythonpath"
+  mkdir -p "${site_dir}"
+  cat > "${fake_meili}" <<'SH'
+#!/bin/sh
+printf '[]\n'
+SH
+  cat > "${site_dir}/sitecustomize.py" <<'PY'
+import os
+import subprocess
+import time
+
+_original_run = subprocess.run
+
+def _run(command, *args, **kwargs):
+    if command and os.path.abspath(command[0]) == os.environ["STUCK_MEILI_PATH"]:
+        time.sleep(20)
+        return subprocess.CompletedProcess(command, 0, "[]\n", "")
+    return _original_run(command, *args, **kwargs)
+
+subprocess.run = _run
+PY
+  chmod +x "${fake_meili}"
+
+  if env \
+    -u SUPERMEMORY_API_KEY \
+    -u SUPERMEMORY_CC_API_KEY \
+    HOME="${TMP_DIR}/deadline-home" \
+    CK_SCRATCH_DIR="${TMP_DIR}/deadline-scratch" \
+    CK_RECALL_ROOTS= \
+    CK_SM_ENV="${TMP_DIR}/missing-supermemory-env" \
+    CK_SM_CONTAINER= \
+    CK_RECALL_MEILI_CMD="${fake_meili}" \
+    STUCK_MEILI_PATH="${fake_meili}" \
+    STUCK_SITE_DIR="${site_dir}" \
+    RECALL_PATH="${RECALL}" \
+    python3 -B - <<'PY'
+import os
+import subprocess
+import time
+
+child_env = os.environ.copy()
+child_env["PYTHONPATH"] = os.environ["STUCK_SITE_DIR"]
+started = time.monotonic()
+completed = subprocess.run(
+    [os.environ["RECALL_PATH"], "deadline-probe", "--layers", "meili"],
+    env=child_env,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    check=False,
+    timeout=12.5,
+)
+elapsed = time.monotonic() - started
+
+print(
+    "deadline elapsed={:.2f}s rc={} stdout={!r} stderr={!r}".format(
+        elapsed, completed.returncode, completed.stdout, completed.stderr
+    )
+)
+assert completed.returncode == 1, completed.returncode
+assert elapsed <= 12.0, elapsed
+assert "layer=meili status=error hits=0" in completed.stdout
+assert "reason=timeout after 10s" in completed.stdout
+assert "recall: no selected layer completed" in completed.stderr
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "the CLI process must exit no later than the outer deadline plus two seconds"
   fi
 }
 
@@ -359,6 +474,46 @@ SH
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "grep should run and parse provenance when rg is absent"
+  fi
+}
+
+case_colon_path_survives_rg_and_grep_fallback() {
+  local case_name="colon-path-survives-rg-and-grep-fallback"
+  local root="${TMP_DIR}/colon-root"
+  local forced_rg_bin="${TMP_DIR}/colon-rg-bin"
+  local forced_grep_bin="${TMP_DIR}/colon-grep-bin"
+  local python_path
+  local rg_path
+  local grep_path
+  mkdir -p "${root}" "${forced_rg_bin}" "${forced_grep_bin}"
+  printf 'colon-path-probe\n' > "${root}/foo:12:bar.md"
+  python_path=$(command -v python3)
+  rg_path=$(command -v rg)
+  grep_path=$(command -v grep)
+  ln -s "${python_path}" "${forced_rg_bin}/python3"
+  ln -s "${rg_path}" "${forced_rg_bin}/rg"
+  ln -s "${python_path}" "${forced_grep_bin}/python3"
+  ln -s "${grep_path}" "${forced_grep_bin}/grep"
+
+  run_clean "${TMP_DIR}/colon-rg-scratch" env \
+    PATH="${forced_rg_bin}" CK_RECALL_ROOTS="${root}" \
+    "${RECALL}" colon-path-probe --layers grep
+  if [ "${RUN_STATUS}" != "0" ] ||
+     ! grep -Fq 'layer=grep status=ok hits=1' "${RUN_STDOUT}" ||
+     ! grep -Fq "[grep] ${root}/foo:12:bar.md:1" "${RUN_STDOUT}"; then
+    record_fail "${case_name}" "rg should count a hit whose path contains a colon"
+    return
+  fi
+
+  run_clean "${TMP_DIR}/colon-grep-scratch" env \
+    PATH="${forced_grep_bin}" CK_RECALL_ROOTS="${root}" \
+    "${RECALL}" colon-path-probe --layers grep
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'layer=grep status=ok hits=1' "${RUN_STDOUT}" &&
+     grep -Fq "[grep] ${root}/foo:12:bar.md:1" "${RUN_STDOUT}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "grep fallback should preserve the full colon-bearing path"
   fi
 }
 
@@ -434,6 +589,128 @@ PY
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "expected canonical/direct precedence and legacy env-file compatibility"
+  fi
+}
+
+case_supermemory_loopback_contract() {
+  local case_name="supermemory-loopback-contract"
+  if env RECALL_PATH="${RECALL}" python3 -B - <<'PY'
+import importlib.machinery
+import importlib.util
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+path = os.environ["RECALL_PATH"]
+loader = importlib.machinery.SourceFileLoader("context_kit_recall_sm_contract", path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+observed = {}
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        observed["authorization"] = self.headers.get("Authorization")
+        observed["body"] = json.loads(self.rfile.read(length).decode("utf-8"))
+        payload = {
+            "result": {
+                "data": [
+                    {"id": "memory-one", "content": "first"},
+                    {"memoryId": "memory-two", "text": "second"},
+                    {"id": "memory-three", "content": "must be sliced"},
+                ]
+            }
+        }
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, format, *args):
+        pass
+
+try:
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+except OSError as exc:
+    print("SKIP loopback bind unavailable: {}".format(exc))
+    raise SystemExit(0)
+
+thread = threading.Thread(target=server.serve_forever, daemon=True)
+thread.start()
+try:
+    host, port = server.server_address
+    module.SM_API_URL = "http://{}:{}/search".format(host, port)
+    hits = module.supermemory_search("contract-probe", 2, "test-key", "default-box")
+finally:
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=1)
+
+assert observed["authorization"] == "Bearer test-key"
+assert observed["body"] == {
+    "q": "contract-probe",
+    "containerTag": "default-box",
+    "limit": 2,
+}
+assert len(hits) == 2
+assert [item["containerTag"] for item in hits] == ["default-box", "default-box"]
+emitted, rejected = module.emit_hits("sm", hits)
+assert rejected == 0
+assert [item["pointer"] for item in emitted] == [
+    "supermemory:memory-one containerTag=default-box",
+    "supermemory:memory-two containerTag=default-box",
+]
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "loopback response parsing, defaults, limit, and pointers should stay stable"
+  fi
+}
+
+case_meili_transcript_pointer_contract() {
+  local case_name="meili-transcript-pointer-contract"
+  local transcript_home="${TMP_DIR}/transcript-home"
+  local project="fixture-project"
+  local session_id="fixture-session"
+  local transcript_dir="${transcript_home}/.claude/projects/${project}"
+  local transcript="${transcript_dir}/${session_id}.jsonl"
+  local fake_meili="${TMP_DIR}/transcript-mem-search"
+  mkdir -p "${transcript_dir}"
+  printf '{"role":"user","text":"fixture"}\n' > "${transcript}"
+  cat > "${fake_meili}" <<'SH'
+#!/bin/sh
+printf '{"hits":[{"_index":"transcripts","project":"%s","session_id":"%s","title":"Transcript","content":"fixture snippet"}]}\n' "${TRANSCRIPT_PROJECT}" "${TRANSCRIPT_SESSION_ID}"
+SH
+  chmod +x "${fake_meili}"
+
+  run_capture env \
+    -u SUPERMEMORY_API_KEY -u SUPERMEMORY_CC_API_KEY \
+    HOME="${transcript_home}" CK_SCRATCH_DIR="${TMP_DIR}/transcript-scratch" \
+    CK_RECALL_ROOTS= CK_SM_ENV="${TMP_DIR}/missing" CK_SM_CONTAINER= \
+    CK_RECALL_MEILI_CMD="${fake_meili}" \
+    TRANSCRIPT_PROJECT="${project}" TRANSCRIPT_SESSION_ID="${session_id}" \
+    "${RECALL}" transcript-probe --layers meili --json
+  if [ "${RUN_STATUS}" = "0" ] &&
+     python3 - "${RUN_STDOUT}" "${transcript} (session_id=${session_id})" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    result = json.load(handle)
+assert result["per_layer"]["meili"]["status"] == "ok"
+assert result["top_hits"][0]["pointer"] == sys.argv[2]
+assert result["top_hits"][0]["snippet"] == "fixture snippet"
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "transcript-shaped Meili hits should resolve to an existing JSONL pointer"
   fi
 }
 
@@ -550,13 +827,18 @@ case_usage_and_validation
 case_default_degrades_and_grep_runs
 case_no_roots_and_explicit_unavailable_nonzero
 case_nonexistent_roots_are_dropped
-case_local_only_maps_exactly
+case_local_only_filters_selected_layers
 case_fake_meili_parse_and_round_robin_merge
-case_runnable_error_is_fail_soft
+case_all_attempted_errors_exit_nonzero_with_stderr_guidance
+case_layer_error_isolated_from_success
 case_outer_timeout_bounds_library_call
+case_cli_process_honors_outer_deadline
 case_rg_preferred_and_grep_fallback
+case_colon_path_survives_rg_and_grep_fallback
 case_configured_path_expansion
 case_supermemory_key_resolution
+case_supermemory_loopback_contract
+case_meili_transcript_pointer_contract
 case_default_scratch_and_home_unset
 case_whole_failure_is_clear_english
 case_python39_stdlib_executable_and_clean

--- a/tests/test_recall.sh
+++ b/tests/test_recall.sh
@@ -1,0 +1,564 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+RECALL="${ROOT}/bin/recall"
+TMP_DIR=$(mktemp -d)
+PASS_COUNT=0
+FAIL_COUNT=0
+RUN_STDOUT=""
+RUN_STDERR=""
+RUN_STATUS=0
+
+cleanup() {
+  chmod -R u+rwx "${TMP_DIR}" 2>/dev/null || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+run_capture() {
+  RUN_STDOUT="${TMP_DIR}/stdout.${RANDOM}"
+  RUN_STDERR="${TMP_DIR}/stderr.${RANDOM}"
+  if "$@" >"${RUN_STDOUT}" 2>"${RUN_STDERR}"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+}
+
+run_clean() {
+  local scratch_dir="$1"
+  shift
+  run_capture env \
+    -u SUPERMEMORY_API_KEY \
+    -u SUPERMEMORY_CC_API_KEY \
+    HOME="${TMP_DIR}/home" \
+    CK_AGENT=test-agent \
+    CK_SCRATCH_DIR="${scratch_dir}" \
+    CK_SM_ENV="${TMP_DIR}/missing-supermemory-env" \
+    CK_SM_CONTAINER= \
+    CK_RECALL_MEILI_CMD=context-kit-missing-mem-search \
+    "$@"
+}
+
+record_pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+record_fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+finish() {
+  printf '%d passed, %d failed\n' "${PASS_COUNT}" "${FAIL_COUNT}"
+  if [ "${FAIL_COUNT}" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+scratch_path_from_human() {
+  sed -n 's/^scratch: //p' "$1" | tail -n 1
+}
+
+path_mode() {
+  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
+case_usage_and_validation() {
+  local case_name="usage-and-validation"
+  run_clean "${TMP_DIR}/usage-scratch" "${RECALL}"
+  if [ "${RUN_STATUS}" = "2" ] && grep -Fq 'usage: recall' "${RUN_STDERR}"; then
+    :
+  else
+    record_fail "${case_name}" "missing query should exit 2 with argparse usage"
+    return
+  fi
+
+  run_clean "${TMP_DIR}/limit-scratch" "${RECALL}" probe --limit 0
+  if [ "${RUN_STATUS}" = "2" ] && grep -Fq -- '--limit must be at least 1' "${RUN_STDERR}"; then
+    :
+  else
+    record_fail "${case_name}" "invalid limit should exit 2 with a clear reason"
+    return
+  fi
+
+  run_clean "${TMP_DIR}/layer-scratch" "${RECALL}" probe --layers unknown
+  if [ "${RUN_STATUS}" = "2" ] && grep -Fq "unknown layer 'unknown'" "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "unknown layers should be rejected"
+  fi
+}
+
+case_default_degrades_and_grep_runs() {
+  local case_name="default-degrades-and-grep-runs"
+  local root="${TMP_DIR}/default-root"
+  local scratch="${TMP_DIR}/default-scratch"
+  local scratch_file
+  mkdir -p "${root}"
+  printf 'the context-kit recall needle\n' > "${root}/note.md"
+
+  run_clean "${scratch}" env CK_RECALL_ROOTS="${root}" "${RECALL}" needle
+  scratch_file=$(scratch_path_from_human "${RUN_STDOUT}")
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'layer=sm status=skip hits=0 latency_ms=0 reason=CK_SM_CONTAINER and SUPERMEMORY_API_KEY are not configured' "${RUN_STDOUT}" &&
+     grep -Fq 'layer=meili status=skip hits=0 latency_ms=0 reason=mem-search command is unavailable' "${RUN_STDOUT}" &&
+     grep -Fq 'layer=grep status=ok hits=1' "${RUN_STDOUT}" &&
+     grep -Fq "[grep] ${root}/note.md:1" "${RUN_STDOUT}" &&
+     [ -n "${scratch_file}" ] && [ -f "${scratch_file}" ] &&
+     grep -Fq 'mode: proactive-recall' "${scratch_file}" &&
+     grep -Fq 'expiresAt:' "${scratch_file}" &&
+     grep -Fq 'layer=sm status=skip' "${scratch_file}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected two skips, one successful grep, provenance, and a result dump"
+  fi
+}
+
+case_no_roots_and_explicit_unavailable_nonzero() {
+  local case_name="no-roots-and-explicit-unavailable-nonzero"
+  run_clean "${TMP_DIR}/no-roots-scratch" env CK_RECALL_ROOTS= "${RECALL}" probe --layers grep
+  if [ "${RUN_STATUS}" = "1" ] &&
+     grep -Fq 'layer=grep status=skip hits=0 latency_ms=0 reason=no roots' "${RUN_STDOUT}"; then
+    :
+  else
+    record_fail "${case_name}" "empty roots should skip grep and exit nonzero"
+    return
+  fi
+
+  run_clean "${TMP_DIR}/missing-roots-scratch" env \
+    CK_RECALL_ROOTS="${TMP_DIR}/missing-one:${TMP_DIR}/missing-two" \
+    "${RECALL}" probe --layers grep
+  if [ "${RUN_STATUS}" = "1" ] &&
+     grep -Fq 'layer=grep status=skip hits=0 latency_ms=0 reason=no roots' "${RUN_STDOUT}"; then
+    :
+  else
+    record_fail "${case_name}" "all-missing explicit roots should skip grep and exit nonzero"
+    return
+  fi
+
+  run_clean "${TMP_DIR}/sm-only-scratch" "${RECALL}" probe --layers sm
+  if [ "${RUN_STATUS}" = "1" ] &&
+     grep -Fq 'layer=sm status=skip hits=0 latency_ms=0 reason=CK_SM_CONTAINER and SUPERMEMORY_API_KEY are not configured' "${RUN_STDOUT}" &&
+     [ -f "$(scratch_path_from_human "${RUN_STDOUT}")" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "an unavailable-only explicit selection should exit nonzero after reporting"
+  fi
+}
+
+case_nonexistent_roots_are_dropped() {
+  local case_name="nonexistent-roots-are-dropped"
+  local root="${TMP_DIR}/existing-root"
+  mkdir -p "${root}"
+  printf 'root-filter-probe\n' > "${root}/memory.txt"
+  run_clean "${TMP_DIR}/root-filter-scratch" env \
+    CK_RECALL_ROOTS="${TMP_DIR}/does-not-exist:${root}:${TMP_DIR}/also-missing" \
+    "${RECALL}" root-filter-probe --layers grep
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'layer=grep status=ok hits=1' "${RUN_STDOUT}" &&
+     ! grep -Fq 'does-not-exist' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected missing roots to disappear silently while the existing root runs"
+  fi
+}
+
+case_local_only_maps_exactly() {
+  local case_name="local-only-maps-exactly"
+  local root="${TMP_DIR}/local-root"
+  mkdir -p "${root}"
+  printf 'local-map-probe\n' > "${root}/local.md"
+  run_clean "${TMP_DIR}/local-scratch" env CK_RECALL_ROOTS="${root}" \
+    "${RECALL}" local-map-probe --layers sm --local-only --json
+  if [ "${RUN_STATUS}" = "0" ] && python3 - "${RUN_STDOUT}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    result = json.load(handle)
+assert result["layers_queried"] == ["meili", "grep"]
+assert list(result["per_layer"]) == ["grep", "meili"] or set(result["per_layer"]) == {"meili", "grep"}
+assert result["per_layer"]["meili"]["status"] == "skip"
+assert result["per_layer"]["grep"]["status"] == "ok"
+assert all("reason" in item for item in result["per_layer"].values())
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "--local-only should select meili,grep regardless of --layers"
+  fi
+}
+
+case_fake_meili_parse_and_round_robin_merge() {
+  local case_name="fake-meili-parse-and-round-robin-merge"
+  local root="${TMP_DIR}/merge-root"
+  local scratch="${TMP_DIR}/merge-scratch"
+  local fake_meili="${TMP_DIR}/fake-mem-search"
+  local meili_file_one="${TMP_DIR}/meili-one.md"
+  local meili_file_two="${TMP_DIR}/meili-two.md"
+  local args_file="${TMP_DIR}/meili-args"
+  mkdir -p "${root}"
+  printf 'merge-probe grep one\nmerge-probe grep two\n' > "${root}/grep.md"
+  printf 'one\n' > "${meili_file_one}"
+  printf 'two\n' > "${meili_file_two}"
+
+  cat > "${fake_meili}" <<'SH'
+#!/bin/sh
+printf '%s\n' "$@" > "${MEILI_ARGS_FILE}"
+printf '{"hits":[{"path":"%s","title":"Meili One","content":"first remote"},{"path":"%s","title":"Meili Two","content":"second remote"}]}\n' "${MEILI_FILE_ONE}" "${MEILI_FILE_TWO}"
+SH
+  chmod +x "${fake_meili}"
+
+  run_clean "${scratch}" env \
+    CK_RECALL_ROOTS="${root}" \
+    CK_RECALL_MEILI_CMD="${fake_meili}" \
+    MEILI_ARGS_FILE="${args_file}" \
+    MEILI_FILE_ONE="${meili_file_one}" \
+    MEILI_FILE_TWO="${meili_file_two}" \
+    "${RECALL}" merge-probe --layers meili,grep --limit 3 --json
+
+  if [ "${RUN_STATUS}" = "0" ] &&
+     [ "$(sed -n '1p' "${args_file}")" = "--json" ] &&
+     [ "$(sed -n '2p' "${args_file}")" = "-l" ] &&
+     [ "$(sed -n '3p' "${args_file}")" = "3" ] &&
+     [ "$(sed -n '4p' "${args_file}")" = "--" ] &&
+     [ "$(sed -n '5p' "${args_file}")" = "merge-probe" ] &&
+     python3 - "${RUN_STDOUT}" "${meili_file_one}" "${root}/grep.md" "${meili_file_two}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    result = json.load(handle)
+assert result["per_layer"]["meili"]["status"] == "ok"
+assert result["per_layer"]["grep"]["status"] == "ok"
+assert [hit["layer"] for hit in result["top_hits"]] == ["meili", "grep", "meili"]
+assert [hit["pointer"] for hit in result["top_hits"]] == [sys.argv[2], sys.argv[3] + ":1", sys.argv[4]]
+assert len(result["hits"]) >= len(result["top_hits"]) == 3
+assert result["top_hits"][0]["title"] == "Meili One"
+assert result["top_hits"][0]["snippet"] == "first remote"
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected original mem-search argv, JSON parsing, provenance, and meili/grep round robin"
+  fi
+}
+
+case_runnable_error_is_fail_soft() {
+  local case_name="runnable-error-is-fail-soft"
+  local fake_meili="${TMP_DIR}/bad-mem-search"
+  cat > "${fake_meili}" <<'SH'
+#!/bin/sh
+printf 'not-json\n'
+SH
+  chmod +x "${fake_meili}"
+
+  run_clean "${TMP_DIR}/error-scratch" env CK_RECALL_MEILI_CMD="${fake_meili}" \
+    "${RECALL}" probe --layers meili
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'layer=meili status=error hits=0' "${RUN_STDOUT}" &&
+     grep -Fq 'reason=mem-search returned invalid JSON:' "${RUN_STDOUT}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "a runnable layer error should be reported but still exit 0"
+  fi
+}
+
+case_outer_timeout_bounds_library_call() {
+  local case_name="outer-timeout-bounds-library-call"
+  if env \
+    RECALL_PATH="${RECALL}" \
+    CK_SCRATCH_DIR="${TMP_DIR}/outer-timeout-scratch" \
+    python3 -B - <<'PY'
+import importlib.machinery
+import importlib.util
+import os
+import time
+
+path = os.environ["RECALL_PATH"]
+loader = importlib.machinery.SourceFileLoader("context_kit_recall_timeout", path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+def slow_adapter(query, limit):
+    time.sleep(0.25)
+    return []
+
+module.build_layer_plans = lambda selected: ({"grep": slow_adapter}, {})
+started = time.monotonic()
+result = module.recall("probe", ["grep"], 1, timeout=0.01)
+elapsed = time.monotonic() - started
+assert elapsed < 0.15, elapsed
+assert result["exit_code"] == 0
+assert result["per_layer"]["grep"]["status"] == "error"
+assert result["per_layer"]["grep"]["reason"] == "timeout after 0.01s"
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "outer future deadline should return a timeout result without awaiting a slow adapter"
+  fi
+}
+
+case_rg_preferred_and_grep_fallback() {
+  local case_name="rg-preferred-and-grep-fallback"
+  local root="${TMP_DIR}/tool-root"
+  local preferred_bin="${TMP_DIR}/preferred-bin"
+  local fallback_bin="${TMP_DIR}/fallback-bin"
+  local python_path
+  mkdir -p "${root}" "${preferred_bin}" "${fallback_bin}"
+  printf 'tool-probe\n' > "${root}/tool.md"
+  python_path=$(command -v python3)
+  ln -s "${python_path}" "${preferred_bin}/python3"
+  ln -s "${python_path}" "${fallback_bin}/python3"
+
+  cat > "${preferred_bin}/rg" <<'SH'
+#!/bin/sh
+: > "${RG_MARKER}"
+exit 1
+SH
+  cat > "${preferred_bin}/grep" <<'SH'
+#!/bin/sh
+: > "${GREP_MARKER}"
+exit 1
+SH
+  chmod +x "${preferred_bin}/rg" "${preferred_bin}/grep"
+  run_clean "${TMP_DIR}/preferred-scratch" env \
+    PATH="${preferred_bin}" CK_RECALL_ROOTS="${root}" \
+    RG_MARKER="${TMP_DIR}/rg-used" GREP_MARKER="${TMP_DIR}/grep-not-used" \
+    "${RECALL}" tool-probe --layers grep
+  if [ "${RUN_STATUS}" = "0" ] && [ -f "${TMP_DIR}/rg-used" ] && [ ! -f "${TMP_DIR}/grep-not-used" ]; then
+    :
+  else
+    record_fail "${case_name}" "rg should be selected when both commands resolve"
+    return
+  fi
+
+  cat > "${fallback_bin}/grep" <<'SH'
+#!/bin/sh
+: > "${GREP_MARKER}"
+printf '%s:7:fallback tool-probe\n' "${GREP_HIT_FILE}"
+SH
+  chmod +x "${fallback_bin}/grep"
+  run_clean "${TMP_DIR}/fallback-scratch" env \
+    PATH="${fallback_bin}" CK_RECALL_ROOTS="${root}" \
+    GREP_MARKER="${TMP_DIR}/grep-used" GREP_HIT_FILE="${root}/tool.md" \
+    "${RECALL}" tool-probe --layers grep
+  if [ "${RUN_STATUS}" = "0" ] &&
+     [ -f "${TMP_DIR}/grep-used" ] &&
+     grep -Fq "[grep] ${root}/tool.md:7" "${RUN_STDOUT}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "grep should run and parse provenance when rg is absent"
+  fi
+}
+
+case_configured_path_expansion() {
+  local case_name="configured-path-expansion"
+  local temp_home="${TMP_DIR}/path-home"
+  local scratch_dir="${temp_home}/scratch-out"
+  local shim="${temp_home}/bin/mem-search"
+  mkdir -p "${scratch_dir}" "${temp_home}/bin"
+  chmod 755 "${scratch_dir}"
+  cat > "${shim}" <<'SH'
+#!/bin/sh
+printf '[]\n'
+SH
+  chmod +x "${shim}"
+
+  run_capture env \
+    -u SUPERMEMORY_API_KEY -u SUPERMEMORY_CC_API_KEY \
+    HOME="${temp_home}" CK_SCRATCH_DIR='~/scratch-out' CK_RECALL_ROOTS= \
+    CK_SM_ENV="${TMP_DIR}/missing" CK_SM_CONTAINER= \
+    CK_RECALL_MEILI_CMD='~/bin/mem-search' \
+    "${RECALL}" path-probe --layers meili
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'layer=meili status=ok hits=0' "${RUN_STDOUT}" &&
+     [ "$(path_mode "${scratch_dir}")" = "755" ] &&
+     case "$(scratch_path_from_human "${RUN_STDOUT}")" in "${scratch_dir}/"*) true ;; *) false ;; esac; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "literal tilde paths should expand for scratch output and the Meili executable"
+  fi
+}
+
+case_supermemory_key_resolution() {
+  local case_name="supermemory-key-resolution"
+  local env_file="${TMP_DIR}/supermemory.env"
+  printf 'export SUPERMEMORY_CC_API_KEY="legacy-file-key"\n' > "${env_file}"
+  if env \
+    -u SUPERMEMORY_API_KEY \
+    -u SUPERMEMORY_CC_API_KEY \
+    CK_SM_ENV="${env_file}" \
+    RECALL_PATH="${RECALL}" \
+    python3 -B - <<'PY'
+import importlib.machinery
+import importlib.util
+import os
+
+path = os.environ["RECALL_PATH"]
+loader = importlib.machinery.SourceFileLoader("context_kit_recall", path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+assert module.resolve_sm_api_key() == "legacy-file-key"
+os.environ["SUPERMEMORY_CC_API_KEY"] = "legacy-direct-key"
+assert module.resolve_sm_api_key() == "legacy-direct-key"
+os.environ["SUPERMEMORY_API_KEY"] = "canonical-direct-key"
+assert module.resolve_sm_api_key() == "canonical-direct-key"
+os.environ["CK_SM_CONTAINER"] = ""
+adapters, skips = module.build_layer_plans(["sm"])
+assert adapters == {}
+assert skips["sm"] == "CK_SM_CONTAINER is not configured"
+os.environ.pop("SUPERMEMORY_API_KEY")
+os.environ.pop("SUPERMEMORY_CC_API_KEY")
+os.environ["CK_SM_ENV"] = os.path.join(os.path.dirname(path), "missing-sm-env")
+os.environ["CK_SM_CONTAINER"] = "configured-container"
+adapters, skips = module.build_layer_plans(["sm"])
+assert adapters == {}
+assert skips["sm"] == "SUPERMEMORY_API_KEY is not configured"
+os.environ["SUPERMEMORY_API_KEY"] = "canonical-direct-key"
+adapters, skips = module.build_layer_plans(["sm"])
+assert "sm" in adapters and "sm" not in skips
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected canonical/direct precedence and legacy env-file compatibility"
+  fi
+}
+
+case_default_scratch_and_home_unset() {
+  local case_name="default-scratch-and-home-unset"
+  local seeded_home="${TMP_DIR}/seeded-home"
+  local seeded_root="${seeded_home}/.claude/scratch/recall-agent/memory"
+  local clean_home="${TMP_DIR}/clean-home"
+  local clean_root="${clean_home}/.claude/scratch/clean-agent/memory"
+  mkdir -p "${seeded_root}" "${clean_home}"
+  printf 'default-root-probe\n' > "${seeded_root}/seeded.md"
+  run_capture env \
+    -u CK_SCRATCH_DIR -u CK_RECALL_ROOTS -u SUPERMEMORY_API_KEY -u SUPERMEMORY_CC_API_KEY \
+    HOME="${seeded_home}" CK_AGENT=recall-agent CK_SM_ENV="${TMP_DIR}/missing" CK_SM_CONTAINER= \
+    CK_RECALL_MEILI_CMD=context-kit-missing-mem-search \
+    "${RECALL}" default-root-probe
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'layer=sm status=skip hits=0 latency_ms=0 reason=CK_SM_CONTAINER and SUPERMEMORY_API_KEY are not configured' "${RUN_STDOUT}" &&
+     grep -Fq 'layer=meili status=skip hits=0 latency_ms=0 reason=mem-search command is unavailable' "${RUN_STDOUT}" &&
+     grep -Fq 'layer=grep status=ok hits=1' "${RUN_STDOUT}" &&
+     grep -Fq "[grep] ${seeded_root}/seeded.md:1" "${RUN_STDOUT}" &&
+     [ "$(path_mode "${seeded_root}")" = "700" ] &&
+     case "$(scratch_path_from_human "${RUN_STDOUT}")" in "${seeded_root}/"*) true ;; *) false ;; esac; then
+    :
+  else
+    record_fail "${case_name}" "seeded default scratch should be searched with degraded optional layers"
+    return
+  fi
+
+  run_capture env \
+    -u CK_SCRATCH_DIR -u CK_RECALL_ROOTS -u SUPERMEMORY_API_KEY -u SUPERMEMORY_CC_API_KEY \
+    HOME="${clean_home}" CK_AGENT=clean-agent CK_SM_ENV="${TMP_DIR}/missing" CK_SM_CONTAINER= \
+    CK_RECALL_MEILI_CMD=context-kit-missing-mem-search \
+    "${RECALL}" absent-probe --layers grep
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'layer=grep status=ok hits=0' "${RUN_STDOUT}" &&
+     [ -d "${clean_root}" ] &&
+     [ "$(path_mode "${clean_root}")" = "700" ] &&
+     case "$(scratch_path_from_human "${RUN_STDOUT}")" in "${clean_root}/"*) true ;; *) false ;; esac; then
+    :
+  else
+    record_fail "${case_name}" "clean HOME should prepare the default root and run grep with zero hits"
+    return
+  fi
+
+  run_capture env \
+    -u HOME -u CK_SCRATCH_DIR -u CK_RECALL_ROOTS -u SUPERMEMORY_API_KEY -u SUPERMEMORY_CC_API_KEY \
+    TMPDIR="${TMP_DIR}/tmp-root" CK_SM_ENV= CK_SM_CONTAINER= \
+    CK_RECALL_MEILI_CMD=context-kit-missing-mem-search \
+    "${RECALL}" probe --layers grep
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'layer=grep status=ok hits=0' "${RUN_STDOUT}" &&
+     [ "$(path_mode "${TMP_DIR}/tmp-root/context-kit-scratch")" = "700" ] &&
+     case "$(scratch_path_from_human "${RUN_STDOUT}")" in "${TMP_DIR}/tmp-root/context-kit-scratch/"*) true ;; *) false ;; esac; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "HOME-unset runs should use TMPDIR/context-kit-scratch"
+  fi
+}
+
+case_whole_failure_is_clear_english() {
+  local case_name="whole-failure-is-clear-english"
+  local blocked="${TMP_DIR}/scratch-is-file"
+  printf 'not a directory\n' > "${blocked}"
+  run_clean "${blocked}" env CK_RECALL_ROOTS= "${RECALL}" probe --layers grep
+  if [ "${RUN_STATUS}" = "1" ] &&
+     [ ! -s "${RUN_STDOUT}" ] &&
+     grep -Fq 'recall: unexpected failure:' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "whole-command crashes should emit a clear English stderr message and exit nonzero"
+  fi
+}
+
+case_python39_stdlib_executable_and_clean() {
+  local case_name="python39-stdlib-executable-and-clean"
+  local before="${TMP_DIR}/before-bytecode"
+  local after="${TMP_DIR}/after-bytecode"
+  find "${ROOT}/bin" -type d -name __pycache__ -o -name '*.pyc' | sort > "${before}"
+  run_clean "${TMP_DIR}/clean-scratch" env CK_RECALL_ROOTS= \
+    python3 -B "${RECALL}" probe --layers grep --json
+  find "${ROOT}/bin" -type d -name __pycache__ -o -name '*.pyc' | sort > "${after}"
+  if [ "${RUN_STATUS}" = "1" ] &&
+     [ -x "${RECALL}" ] &&
+     cmp -s "${before}" "${after}" &&
+     python3 -B - "${RECALL}" <<'PY'
+import ast
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    source = handle.read()
+ast.parse(source, filename=sys.argv[1], feature_version=(3, 9))
+PY
+  then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected executable Python 3.9-compatible stdlib code and no new bytecode artifacts under bin"
+  fi
+}
+
+case_no_personal_residue() {
+  local case_name="no-personal-residue"
+  local forbidden
+  forbidden="[p]ersonal-[a]lpha|[s]hojikumaru|[S]haredHub|[a]lpha-wiki|[c]laude-workspace|/[U]sers"
+  if ! grep -Eqi "${forbidden}" \
+    "${RECALL}" "${ROOT}/docs/recall.md" "${ROOT}/tests/test_recall.sh"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "ported files must not retain operator-specific defaults"
+  fi
+}
+
+case_usage_and_validation
+case_default_degrades_and_grep_runs
+case_no_roots_and_explicit_unavailable_nonzero
+case_nonexistent_roots_are_dropped
+case_local_only_maps_exactly
+case_fake_meili_parse_and_round_robin_merge
+case_runnable_error_is_fail_soft
+case_outer_timeout_bounds_library_call
+case_rg_preferred_and_grep_fallback
+case_configured_path_expansion
+case_supermemory_key_resolution
+case_default_scratch_and_home_unset
+case_whole_failure_is_clear_english
+case_python39_stdlib_executable_and_clean
+case_no_personal_residue
+finish


### PR DESCRIPTION
Fifth and final equipment (#1): multi-layer memory recall.

- `bin/recall` — CLI querying three memory layers and merging results with per-layer provenance: `sm` (Supermemory semantic search — enabled only when an API key AND `CK_SM_CONTAINER` are configured), `meili` (local full-text via a pluggable external command, `CK_RECALL_MEILI_CMD`, default `mem-search`), `grep` (rg-preferred filesystem search over `CK_RECALL_ROOTS`, default = kit scratch dir + `~/.claude/projects`). **Degrade-by-default** (owner decision 2026-08-07): unconfigured layers auto-skip with visible status lines; a clean machine gets a working grep-layer search out of the box; explicit `--layers` requests for unconfigured layers produce clear guidance; non-zero exit only when no layer could run.
- Personal defaults removed (container tag, roots, paths); bounded network timeouts; per-layer fail-soft (one layer erroring never kills the others).
- `docs/recall.md` includes the required FMA-relationship section (individual memory vs the family's shared memory tile).
- `tests/test_recall.sh` — 15 cases incl. fake-meili parse-contract lock, skip semantics, default-root resolution, self-clean residue check.
- Local identifier kept scanner-clean (common `api_key = <long value>` heuristics).

**Implementation**: Codex GPT-5.6 Sol (high) / orchestration+commit: maintainer orchestrator
**Review seats**: GLM 5.2 + Opus 5 + Grok 4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
