### PR TITLE
fix: family footer placement (below Learn more)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -198,20 +198,6 @@ for t in tests/*.sh; do bash "$t"; done
 | 全環境変数・ファイル契約・終了コードの規則 | [詳細仕様](docs/reference.ja.md)（[🇺🇸 English](docs/reference.md)） |
 | 装備を1つずつ、導入と検証の手順つきで | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) |
 
----
-
-<a id="license"></a>
-
-## ライセンス
-
-[MIT](LICENSE) です。このキットは「気に入った装備を自分の環境に自由に写して使ってほしい」ために存在します。ゆるい許諾は脚注ではなく目的そのものです。
-
-<div align="center">
-
-**素の hooks + 小さな CLI** ｜ **fail-open 設計** ｜ **MIT**
-
-</div>
-
 <!-- family:generated:family-footer:start -->
 
 ---
@@ -232,3 +218,18 @@ for t in tests/*.sh; do bash "$t"; done
 | 横軸 | [Sitter](https://github.com/caty-ai/sitter) | 委譲したエージェント実行の見張り番 — 監視・証拠の記録・再起動 | 公開・MIT |
 
 <!-- family:generated:family-footer:end -->
+
+---
+
+<a id="license"></a>
+
+## ライセンス
+
+[MIT](LICENSE) です。このキットは「気に入った装備を自分の環境に自由に写して使ってほしい」ために存在します。ゆるい許諾は脚注ではなく目的そのものです。
+
+<div align="center">
+
+**素の hooks + 小さな CLI** ｜ **fail-open 設計** ｜ **MIT**
+
+</div>
+

--- a/README.md
+++ b/README.md
@@ -198,20 +198,6 @@ The details live in reader-specific docs, one level deeper.
 | Every environment variable, file contract, and exit-code rule | [Reference](docs/reference.md)（[🇯🇵 日本語](docs/reference.ja.md)） |
 | One piece at a time, with install and verify steps | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) |
 
----
-
-<a id="license"></a>
-
-## License
-
-[MIT](LICENSE). The kit exists so you can copy pieces into your own setup freely — a permissive license is the point, not a footnote.
-
-<div align="center">
-
-**Plain hooks + small CLIs** ｜ **Fail-open by design** ｜ **MIT**
-
-</div>
-
 <!-- family:generated:family-footer:start -->
 
 ---
@@ -232,3 +218,18 @@ Part of the **Caty AI family** — open tools for running a family of AI agents.
 | Horizontal | [Sitter](https://github.com/caty-ai/sitter) | Babysits delegated agent runs — watches, keeps evidence, restarts | published, MIT |
 
 <!-- family:generated:family-footer:end -->
+
+---
+
+<a id="license"></a>
+
+## License
+
+[MIT](LICENSE). The kit exists so you can copy pieces into your own setup freely — a permissive license is the point, not a footnote.
+
+<div align="center">
+
+**Plain hooks + small CLIs** ｜ **Fail-open by design** ｜ **MIT**
+
+</div>
+

--- a/README.th.md
+++ b/README.th.md
@@ -198,20 +198,6 @@ for t in tests/*.sh; do bash "$t"; done
 | ตัวแปรสภาพแวดล้อมทุกตัว ข้อตกลงไฟล์ และกฎ exit code ทั้งหมด | [เอกสารอ้างอิง](docs/reference.md)（[🇯🇵 日本語](docs/reference.ja.md)） |
 | ทีละชิ้น พร้อมขั้นตอนติดตั้งและตรวจสอบ | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) |
 
----
-
-<a id="license"></a>
-
-## สัญญาอนุญาต
-
-[MIT](LICENSE) คิทนี้มีอยู่เพื่อให้คุณคัดลอกอุปกรณ์แต่ละชิ้นไปใช้ในระบบของคุณเองได้อย่างอิสระ — สัญญาอนุญาตแบบเปิดกว้างคือจุดประสงค์หลัก ไม่ใช่แค่เชิงอรรถ
-
-<div align="center">
-
-**hook ธรรมดา + CLI เล็กๆ** ｜ **ออกแบบแบบ fail-open** ｜ **MIT**
-
-</div>
-
 <!-- family:generated:family-footer:start -->
 
 ---
@@ -232,3 +218,18 @@ for t in tests/*.sh; do bash "$t"; done
 | แกนนอน | [Sitter](https://github.com/caty-ai/sitter) | พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ต | เปิดแล้ว・MIT |
 
 <!-- family:generated:family-footer:end -->
+
+---
+
+<a id="license"></a>
+
+## สัญญาอนุญาต
+
+[MIT](LICENSE) คิทนี้มีอยู่เพื่อให้คุณคัดลอกอุปกรณ์แต่ละชิ้นไปใช้ในระบบของคุณเองได้อย่างอิสระ — สัญญาอนุญาตแบบเปิดกว้างคือจุดประสงค์หลัก ไม่ใช่แค่เชิงอรรถ
+
+<div align="center">
+
+**hook ธรรมดา + CLI เล็กๆ** ｜ **ออกแบบแบบ fail-open** ｜ **MIT**
+
+</div>
+

--- a/README.zh.md
+++ b/README.zh.md
@@ -198,20 +198,6 @@ for t in tests/*.sh; do bash "$t"; done
 | 每个环境变量、文件约定、退出码规则 | [参考文档](docs/reference.md)（[🇯🇵 日本語](docs/reference.ja.md)） |
 | 逐件了解每个装备，含安装和验证步骤 | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) |
 
----
-
-<a id="license"></a>
-
-## 许可协议
-
-[MIT](LICENSE)。这套装备存在的意义，就是让你可以自由地把其中任何一件复制进自己的环境——宽松的许可协议是它的目的，不是附带的一句话。
-
-<div align="center">
-
-**朴素的 hooks + 小巧的 CLI** ｜ **默认 fail-open** ｜ **MIT**
-
-</div>
-
 <!-- family:generated:family-footer:start -->
 
 ---
@@ -232,3 +218,18 @@ for t in tests/*.sh; do bash "$t"; done
 | 横轴 | [Sitter](https://github.com/caty-ai/sitter) | 替你盯着委派出去的智能体 — 监视、留证、重启 | 已公开・MIT |
 
 <!-- family:generated:family-footer:end -->
+
+---
+
+<a id="license"></a>
+
+## 许可协议
+
+[MIT](LICENSE)。这套装备存在的意义，就是让你可以自由地把其中任何一件复制进自己的环境——宽松的许可协议是它的目的，不是附带的一句话。
+
+<div align="center">
+
+**朴素的 hooks + 小巧的 CLI** ｜ **默认 fail-open** ｜ **MIT**
+
+</div>
+


### PR DESCRIPTION
Owner-reported: the footer landed at EOF (below License and the hand footer) because the first render appends when no markers exist. Moved to the contract v3.3 position — directly below the Learn more table, above License — matching sitter. Region bytes unchanged; `family_footer.py render` reports no content change; readme-craft inspect + langs PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)