### PR TITLE
B2: one test entry point — tests/run.sh + Makefile test/lint (#15)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test lint
+
+test:
+	bash tests/run.sh
+
+# lint is intentionally a no-op placeholder until a linter is adopted for
+# this repo. Replace this target once shellcheck (or similar) is wired in.
+lint:
+	@echo "lint: no linter configured yet (placeholder)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Batch test runner: discovers and runs every tests/test_*.sh suite.
+#
+# - No fail-fast: every declared suite is executed even if an earlier one
+#   fails.
+# - Streams each suite's stdout/stderr live (no swallowing).
+# - Prints a PASS/FAIL verdict per suite and a declared/executed summary.
+# - Exits non-zero if any suite fails, or if zero suites are discovered.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TESTS_DIR="${ROOT}/tests"
+
+DECLARED=0
+EXECUTED=0
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_NAMES=""
+
+# Discover suites: tests/test_*.sh, sorted, deterministic. Uses a plain
+# glob (bash 3.2 safe; no mapfile / associative arrays).
+SUITES=()
+for suite in "${TESTS_DIR}"/test_*.sh; do
+  if [ -e "${suite}" ]; then
+    SUITES+=("${suite}")
+  fi
+done
+
+DECLARED=${#SUITES[@]}
+
+if [ "${DECLARED}" -eq 0 ]; then
+  echo "FAIL: no test suites discovered under ${TESTS_DIR}/test_*.sh" >&2
+  echo "declared: 0, executed: 0, passed: 0, failed: 0"
+  exit 1
+fi
+
+for suite in "${SUITES[@]}"; do
+  name=$(basename "${suite}")
+  echo "==> running ${name}"
+
+  status=0
+  if bash "${suite}"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  EXECUTED=$((EXECUTED + 1))
+
+  if [ "${status}" -eq 0 ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "PASS ${name}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_NAMES="${FAILED_NAMES} ${name}"
+    echo "FAIL ${name} (exit ${status})"
+  fi
+done
+
+echo ""
+echo "declared: ${DECLARED}, executed: ${EXECUTED}"
+echo "passed: ${PASS_COUNT}, failed: ${FAIL_COUNT}"
+
+if [ -n "${FAILED_NAMES}" ]; then
+  echo "failed suites:${FAILED_NAMES}"
+fi
+
+if [ "${FAIL_COUNT}" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,11 +19,11 @@ PASS_COUNT=0
 FAIL_COUNT=0
 FAILED_NAMES=""
 
-# Discover suites: tests/test_*.sh, sorted, deterministic. Uses a plain
-# glob (bash 3.2 safe; no mapfile / associative arrays).
+# Discover suites: tests/test_*.sh, in glob expansion order. Uses a plain glob
+# (bash 3.2 safe; no mapfile / associative arrays).
 SUITES=()
 for suite in "${TESTS_DIR}"/test_*.sh; do
-  if [ -e "${suite}" ]; then
+  if [ -e "${suite}" ] || [ -L "${suite}" ]; then
     SUITES+=("${suite}")
   fi
 done


### PR DESCRIPTION
Closes #15. Campaign: caty-ai/family-os#56 (measure B2, family rule 4).

## What
- `tests/run.sh` (new): batch runner for every `tests/test_*.sh` — no fail-fast, streams suite output, per-suite `PASS`/`FAIL`, summary with `declared`/`executed` counts, exit 1 on any failure or zero discovered suites. Dangling suite symlinks are declared and FAIL (fail-closed). bash 3.2 safe.
- `Makefile` (new): `.PHONY: test lint`; `test` = `bash tests/run.sh`; `lint` = explicit no-op placeholder (commented in-file) until a linter is adopted.

## Files touched (matches Issue prediction — L0-6)
- tests/run.sh (new)
- Makefile (new)

No existing test script modified (`git show 4d77e54 24f22e1 --stat`).

## Evidence
- `make test` on this branch: `declared: 7, executed: 7, passed: 7, failed: 0`, exit 0
- `make lint`: exit 0 with placeholder notice
- Gate proof: injected failing suite → `FAIL` reported, runner exit 1; dangling symlink → `FAIL (exit 127)`, runner exit 1; empty suite dir → exit 1
- Review: 3 seats (GLM 5.3 / Kimi K3 / Grok 4.6) unanimous GO; Grok MINOR (dangling symlink fail-open) fixed in 24f22e1, Grok delta CUMULATIVE GO. Writer: #15 main commit = Sonnet executor (Codex quota outage, ledger-recorded), delta commit = Codex Sol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)