### PR TITLE
B4: badge grammar — green only when a machine painted it (#16)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,8 +8,9 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![python](https://img.shields.io/badge/python-3.9%2B-3776AB?logo=python&logoColor=white)
-![node](https://img.shields.io/badge/node-18%2B_optional-339933?logo=nodedotjs&logoColor=white)
+![node](https://img.shields.io/badge/node-18%2B_optional-lightgrey?logo=nodedotjs&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS_tested_%7C_Linux_unverified-lightgrey)
+![CI](https://img.shields.io/badge/CI-not_yet-lightgrey)
 
 AI エージェントに本物の仕事を任せると、小さな事故がついてきます。巨大なログが作業記憶（会話に持てるコンテキスト）を押し流し、<br>
 危ない削除コマンドまであと1歩、API キーがファイルに書き込まれる寸前——。<br>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![python](https://img.shields.io/badge/python-3.9%2B-3776AB?logo=python&logoColor=white)
-![node](https://img.shields.io/badge/node-18%2B_optional-339933?logo=nodedotjs&logoColor=white)
+![node](https://img.shields.io/badge/node-18%2B_optional-lightgrey?logo=nodedotjs&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS_tested_%7C_Linux_unverified-lightgrey)
+![CI](https://img.shields.io/badge/CI-not_yet-lightgrey)
 
 Hand real work to an AI agent and small accidents follow: one giant log floods its working memory,<br>
 a risky delete is one keystroke away, an API key almost lands in a file.<br>

--- a/README.th.md
+++ b/README.th.md
@@ -8,8 +8,9 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![python](https://img.shields.io/badge/python-3.9%2B-3776AB?logo=python&logoColor=white)
-![node](https://img.shields.io/badge/node-18%2B_optional-339933?logo=nodedotjs&logoColor=white)
+![node](https://img.shields.io/badge/node-18%2B_optional-lightgrey?logo=nodedotjs&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS_tested_%7C_Linux_unverified-lightgrey)
+![CI](https://img.shields.io/badge/CI-not_yet-lightgrey)
 
 มอบงานจริงให้ AI เอเจนต์ทำ แล้วอุบัติเหตุเล็กๆ ก็จะตามมา ล็อกไฟล์มหึมาไฟล์เดียวท่วมความจำการทำงานของมัน<br>
 คำสั่งลบไฟล์อันตรายอยู่ห่างแค่ปุ่มเดียว กุญแจ API เกือบหลุดเข้าไปในไฟล์<br>

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,8 +8,9 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![python](https://img.shields.io/badge/python-3.9%2B-3776AB?logo=python&logoColor=white)
-![node](https://img.shields.io/badge/node-18%2B_optional-339933?logo=nodedotjs&logoColor=white)
+![node](https://img.shields.io/badge/node-18%2B_optional-lightgrey?logo=nodedotjs&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS_tested_%7C_Linux_unverified-lightgrey)
+![CI](https://img.shields.io/badge/CI-not_yet-lightgrey)
 
 把真正的工作交给 AI agent 之后，各种小事故就会跟着来: 一条命令打印出成千上万行日志，把它工作记忆里的旧内容全部挤掉，<br>
 一次危险的删除操作只差一步就要执行，一个 API key 差点被写进文件里。<br>


### PR DESCRIPTION
Closes #16. Campaign: caty-ai/family-os#56 (measure B4, rule 1).

## What
- `node-18+_optional` fact badge: hand-painted green `339933` → `lightgrey` (logo chrome unchanged)
- New honest `CI: not yet` lightgrey badge in all four READMEs (CI arrives with B6/#20)
- license-MIT-blue / python official color / platform badge untouched

## Files touched (matches Issue prediction — L0-6)
README.md / README.ja.md / README.zh.md / README.th.md (badge lines only, +8/−4)

## Evidence
- `grep 339933|brightgreen|4EAA25|success` over the four files → zero hits
- `CI-not_yet-lightgrey` present ×4
- Review: 3 seats (GLM 5.3 / Kimi K3 / Grok 4.6) unanimous GO, notes non-blocking only. Writer: Codex GPT-5.6 Sol

🤖 Generated with [Claude Code](https://claude.com/claude-code)