### PR TITLE
B8: CONTRIBUTING prerequisites + README Project status + make-test guidance (#18)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,26 @@ Thanks for considering a contribution. This kit is small on purpose; contributio
 - **`CK_` prefix** for any new environment variable, with an explicit default documented in [docs/reference.md](docs/reference.md).
 - **Tests are temp-directory-only** and print one `PASS`/`FAIL` line per case. A behavior change needs a case that fails before and passes after.
 
+## Prerequisites
+
+Running the full test suite with `make test` requires:
+
+- **Bash 3.2 or newer.** The batch runner and shell suites stay compatible with the macOS system Bash.
+- **Python 3.9 or newer.** The suites exercise the Python hooks and use Python helpers of their own.
+- **GNU Make 3.81 or newer.** `make test` is the supported full-suite entry point; `make lint` uses the same baseline.
+- **Git.** The safety-hook and `wt-snapshot` suites create and inspect temporary repositories.
+
+Two tools are optional:
+
+- **Node.js 18 or newer.** Without it, the `.mjs` private-repository and API-key guards cannot run, and their case groups are reported as `SKIP`; the rest of the suite still runs.
+- **ripgrep (`rg`).** `recall` normally falls back to POSIX `grep` when `rg` is absent. The `rg`-specific colon-path case is reported as `SKIP`, not a failure.
+
 ## Before you open a PR
 
 1. Run the full suite from the repository root:
 
 ```sh
-for t in tests/*.sh; do bash "$t"; done
+make test
 ```
 
 2. Update the affected doc under `docs/` — behavior and documentation ship together.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ Running the full test suite with `make test` requires:
 
 - **Bash 3.2 or newer.** The batch runner and shell suites stay compatible with the macOS system Bash.
 - **Python 3.9 or newer.** The suites exercise the Python hooks and use Python helpers of their own.
-- **GNU Make 3.81 or newer.** `make test` is the supported full-suite entry point; `make lint` uses the same baseline.
-- **Git.** The safety-hook and `wt-snapshot` suites create and inspect temporary repositories.
+- **GNU Make.** GNU Make is required for `make test` and `make lint`; the stock macOS Make (3.81) is sufficient.
+- **Git.** The `wt-snapshot` suite creates and inspects temporary repositories.
 
 Two tools are optional:
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -157,7 +157,7 @@ export PATH="$PWD/bin:$PATH"
 4. 動作確認。キットの自己チェックは一時ディレクトリだけを使います。
 
 ```sh
-for t in tests/*.sh; do bash "$t"; done
+make test
 ```
 
 全テストケースが `PASS` 行を出せば成功です。出力のどこにも `FAIL` がないことを確認してください（2つのスイートは末尾に失敗ゼロのサマリ行も出ます）。
@@ -203,6 +203,15 @@ for t in tests/*.sh; do bash "$t"; done
 | 全環境変数・ファイル契約・終了コードの規則 | [詳細仕様](docs/reference.ja.md)（[🇺🇸 English](docs/reference.md)） |
 | worktree を消す前の退避、復元、ignored 退避、prune 一覧 | [wt-snapshot](docs/wt-snapshot.ja.md)（[🇺🇸 English](docs/wt-snapshot.md)） |
 | 装備を1つずつ、導入と検証の手順つきで | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) ・ [wt-snapshot](docs/wt-snapshot.ja.md) |
+
+---
+
+## Project status
+
+- **CI:** まだありません。共有 test/lint caller は #20（B6）で導入予定です。それまでは `make test` がローカルのゲートです。
+- **検証済み環境:** macOS（ローカルで検証済み、`make test` は 7/7 suites 成功）｜ Linux は未検証。
+- **成熟度:** v0.2.0 で6番目の装備 `wt-snapshot` をリリースしました。インターフェースは今後も変わる可能性があります。
+- **既知の制限:** safety guard は意図的に fail-open です。guard が壊れてもエージェントをブロックしません。macOS-first であり、`wt-snapshot` の Linux/GNU tar 経路が未検証であることをドキュメントに明記しています。
 
 <!-- family:generated:family-footer:start -->
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -30,6 +30,7 @@ context-kit は、その事故をツール実行のその場所で機械的に�
 - [使いはじめる](#install)
 - [安心して使える理由](#safety)
 - [もっと詳しく](#docs)
+- [Project status](#status)
 - [ライセンス](#license)
 
 ---
@@ -205,6 +206,8 @@ make test
 | 装備を1つずつ、導入と検証の手順つきで | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) ・ [wt-snapshot](docs/wt-snapshot.ja.md) |
 
 ---
+
+<a id="status"></a>
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ context-kit is a six-piece equipment set that stops these accidents mechanically
 - [Get started](#install)
 - [Why it's safe to adopt](#safety)
 - [Learn more](#docs)
+- [Project status](#status)
 - [License](#license)
 
 ---
@@ -205,6 +206,8 @@ The details live in reader-specific docs, one level deeper.
 | One piece at a time, with install and verify steps | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) ・ [wt-snapshot](docs/wt-snapshot.md) |
 
 ---
+
+<a id="status"></a>
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ export PATH="$PWD/bin:$PATH"
 4. Verify. The kit's self-checks run only against temporary directories.
 
 ```sh
-for t in tests/*.sh; do bash "$t"; done
+make test
 ```
 
 Every test case prints a `PASS` line — there should be no `FAIL` anywhere in the output (two suites also end with a zero-failure summary line).
@@ -203,6 +203,15 @@ The details live in reader-specific docs, one level deeper.
 | Every environment variable, file contract, and exit-code rule | [Reference](docs/reference.md)（[🇯🇵 日本語](docs/reference.ja.md)） |
 | Worktree snapshots before deletion, restore, ignored-path capture, and prune listing | [wt-snapshot](docs/wt-snapshot.md)（[🇯🇵 日本語](docs/wt-snapshot.ja.md)） |
 | One piece at a time, with install and verify steps | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) ・ [wt-snapshot](docs/wt-snapshot.md) |
+
+---
+
+## Project status
+
+- **CI:** Not yet. The shared test-and-lint caller is planned for #20 (B6); until then, `make test` is the local gate.
+- **Verified environments:** macOS (tested locally; `make test`: 7/7 suites passed) | Linux unverified.
+- **Maturity:** v0.2.0 shipped the sixth piece, `wt-snapshot`. Interfaces may still move.
+- **Known limits:** Safety guards are fail-open by design: a broken guard never blocks the agent. The project is macOS-first; `wt-snapshot` documents its unverified Linux/GNU tar path.
 
 <!-- family:generated:family-footer:start -->
 

--- a/README.th.md
+++ b/README.th.md
@@ -157,7 +157,7 @@ export PATH="$PWD/bin:$PATH"
 4. ตรวจสอบการทำงาน การเช็คตัวเองของคิทจะรันกับไดเรกทอรีชั่วคราวเท่านั้น
 
 ```sh
-for t in tests/*.sh; do bash "$t"; done
+make test
 ```
 
 ทุกกรณีทดสอบจะพิมพ์บรรทัด `PASS` ออกมา — ในผลลัพธ์ทั้งหมดต้องไม่มี `FAIL` เลย (มี 2 ชุดทดสอบที่จบด้วยบรรทัดสรุปว่าไม่มีความล้มเหลวเพิ่มเติมด้วย)
@@ -203,6 +203,15 @@ for t in tests/*.sh; do bash "$t"; done
 | ตัวแปรสภาพแวดล้อมทุกตัว ข้อตกลงไฟล์ และกฎ exit code ทั้งหมด | [เอกสารอ้างอิง](docs/reference.md)（[🇯🇵 日本語](docs/reference.ja.md)） |
 | เก็บ snapshot ของ worktree ก่อนลบ, กู้คืน, รวม ignored paths และดูรายการ snapshot ที่หมดอายุ | [wt-snapshot](docs/wt-snapshot.md)（[🇯🇵 日本語](docs/wt-snapshot.ja.md)） |
 | ทีละชิ้น พร้อมขั้นตอนติดตั้งและตรวจสอบ | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) ・ [wt-snapshot](docs/wt-snapshot.md) |
+
+---
+
+## Project status
+
+- **CI:** ยังไม่มี โดยมีแผนเพิ่ม test/lint caller ที่ใช้ร่วมกันใน #20 (B6) ระหว่างนี้ `make test` คือด่านตรวจสอบในเครื่อง
+- **สภาพแวดล้อมที่ตรวจสอบแล้ว:** macOS (ทดสอบในเครื่องแล้ว โดย `make test` ผ่าน 7/7 ชุด) | Linux ยังไม่ได้ตรวจสอบ
+- **ระดับความพร้อม:** v0.2.0 เปิดตัวอุปกรณ์ชิ้นที่หกคือ `wt-snapshot` อินเทอร์เฟซยังอาจเปลี่ยนแปลงได้
+- **ข้อจำกัดที่ทราบ:** safety guard ถูกออกแบบให้ fail-open การ์ดที่เสียจะไม่บล็อกเอเจนต์ โปรเจกต์นี้ให้ความสำคัญกับ macOS ก่อน และเอกสารระบุไว้ว่าเส้นทาง Linux/GNU tar ของ `wt-snapshot` ยังไม่ได้รับการตรวจสอบ
 
 <!-- family:generated:family-footer:start -->
 

--- a/README.th.md
+++ b/README.th.md
@@ -30,6 +30,7 @@ context-kit คือชุดอุปกรณ์ 6 ชิ้นที่ห�
 - [เริ่มต้นใช้งาน](#install)
 - [ทำไมถึงปลอดภัยที่จะใช้](#safety)
 - [อ่านเพิ่มเติม](#docs)
+- [Project status](#status)
 - [สัญญาอนุญาต](#license)
 
 ---
@@ -205,6 +206,8 @@ make test
 | ทีละชิ้น พร้อมขั้นตอนติดตั้งและตรวจสอบ | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) ・ [wt-snapshot](docs/wt-snapshot.md) |
 
 ---
+
+<a id="status"></a>
 
 ## Project status
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -30,6 +30,7 @@ context-kit 是一套六件装备，专门在工具运行的那个瞬间，用�
 - [开始使用](#install)
 - [为什么用起来放心](#safety)
 - [了解更多](#docs)
+- [Project status](#status)
 - [许可协议](#license)
 
 ---
@@ -206,12 +207,14 @@ make test
 
 ---
 
+<a id="status"></a>
+
 ## Project status
 
 - **CI:** 尚未配置。共享的 test/lint caller 计划在 #20（B6）中加入；在此之前，`make test` 是本地准入门槛。
 - **已验证环境:** macOS（已在本地验证，`make test` 的 7/7 个套件全部通过）｜ Linux 尚未验证。
 - **成熟度:** v0.2.0 发布了第六件装备 `wt-snapshot`。接口仍可能发生变化。
-- **已知限制:** safety guard 按设计采用 fail-open；guard 损坏时绝不会阻塞 agent。本项目以 macOS 为优先平台；文档已注明 `wt-snapshot` 的 Linux/GNU tar 路径尚未验证。
+- **已知限制:** safety guard 按设计采用 fail-open；不会因 guard 损坏而阻塞 agent。本项目以 macOS 为优先平台；文档已注明 `wt-snapshot` 的 Linux/GNU tar 路径尚未验证。
 
 <!-- family:generated:family-footer:start -->
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -157,7 +157,7 @@ export PATH="$PWD/bin:$PATH"
 4. 验证一下。这套装备的自检只会在临时目录里运行。
 
 ```sh
-for t in tests/*.sh; do bash "$t"; done
+make test
 ```
 
 每个测试用例都会打印一行 `PASS`——输出里不应该出现任何 `FAIL`（其中两个套件末尾还会附一行零失败的汇总）。
@@ -203,6 +203,15 @@ for t in tests/*.sh; do bash "$t"; done
 | 每个环境变量、文件约定、退出码规则 | [参考文档](docs/reference.md)（[🇯🇵 日本語](docs/reference.ja.md)） |
 | 删除前封存 worktree、恢复内容、纳入 ignored 路径，以及只列出可清理快照 | [wt-snapshot](docs/wt-snapshot.md)（[🇯🇵 日本語](docs/wt-snapshot.ja.md)） |
 | 逐件了解每个装备，含安装和验证步骤 | [lg](docs/lg.md) ・ [scratch-persist](docs/scratch-persist.md) ・ [brief-validator](docs/brief-validator.md) ・ [safety-hooks](docs/safety-hooks.md) ・ [recall](docs/recall.md) ・ [wt-snapshot](docs/wt-snapshot.md) |
+
+---
+
+## Project status
+
+- **CI:** 尚未配置。共享的 test/lint caller 计划在 #20（B6）中加入；在此之前，`make test` 是本地准入门槛。
+- **已验证环境:** macOS（已在本地验证，`make test` 的 7/7 个套件全部通过）｜ Linux 尚未验证。
+- **成熟度:** v0.2.0 发布了第六件装备 `wt-snapshot`。接口仍可能发生变化。
+- **已知限制:** safety guard 按设计采用 fail-open；guard 损坏时绝不会阻塞 agent。本项目以 macOS 为优先平台；文档已注明 `wt-snapshot` 的 Linux/GNU tar 路径尚未验证。
 
 <!-- family:generated:family-footer:start -->
 

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -27,7 +27,7 @@ sed "s|<CONTEXT_KIT_DIR>|$PWD|g" examples/settings.json
 出力された `hooks` エントリのうち必要なものを `~/.claude/settings.json` またはプロジェクトの `.claude/settings.json` にマージし、Claude Code を再起動する（または `/hooks` を実行する）、必要に応じて3つの CLI のために `bin/` を `PATH` に追加してください。その後、以下で確認します。
 
 ```sh
-for t in tests/*.sh; do bash "$t"; done
+make test
 ```
 
 すべてのテストスイートは一時ディレクトリのみを使用し、ケースごとに `PASS`/`FAIL` を1行出力します（7つのスイートで合計108ケース）。

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -30,7 +30,7 @@ sed "s|<CONTEXT_KIT_DIR>|$PWD|g" examples/settings.json
 make test
 ```
 
-すべてのテストスイートは一時ディレクトリのみを使用し、ケースごとに `PASS`/`FAIL` を1行出力します（7つのスイートで合計108ケース）。
+7つのテストスイートはすべて一時ディレクトリのみを使用し、ケースごとに `PASS`/`FAIL` を1行出力します。
 
 ---
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -27,7 +27,7 @@ sed "s|<CONTEXT_KIT_DIR>|$PWD|g" examples/settings.json
 Merge the printed `hooks` entries you want into `~/.claude/settings.json` or a project's `.claude/settings.json`, restart Claude Code (or run `/hooks`), and optionally put `bin/` on your `PATH` for the three CLIs. Then verify:
 
 ```sh
-for t in tests/*.sh; do bash "$t"; done
+make test
 ```
 
 All suites are temp-directory-only and print one `PASS`/`FAIL` line per case (108 cases across 7 suites).

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -30,7 +30,7 @@ Merge the printed `hooks` entries you want into `~/.claude/settings.json` or a p
 make test
 ```
 
-All suites are temp-directory-only and print one `PASS`/`FAIL` line per case (108 cases across 7 suites).
+All 7 test suites are temp-directory-only and print one `PASS`/`FAIL` line per case.
 
 ---
 


### PR DESCRIPTION
Closes #18. Campaign: caty-ai/family-os#56 (measure B8).

## What
- CONTRIBUTING.md: new **Prerequisites** section derived from what the suites actually invoke (bash 3.2+ / python 3.9+ / GNU Make / git; node and rg optional with their verified SKIP behavior)
- Test guidance unified to `make test` (README ×4, CONTRIBUTING, docs/engineering en/ja; per-suite debug examples preserved)
- README ×4: **## Project status** — 4 honest fact lines (CI not yet / verified envs / maturity / known limits), same anchor before the family footer, TOC entries added (repo's explicit anchor style)
- `component:wt-snapshot` label created — CONTRIBUTING's `component:*` promise now covers all six pieces
- Truth fixes from review: Git bullet credits wt-snapshot suite only (safety-hooks never touches git), no invented Make version floor, stale hand-written "108 cases" count removed (campaign rule 2), zh nuance aligned to en

## Files touched (declared scope incl. re-declared docs/engineering en/ja — L0-6)
CONTRIBUTING.md, README ×4, docs/engineering.md, docs/engineering.ja.md

## Evidence
- `grep 'for t in tests'` over *.md → 0; `## Project status` ×4 at :212 with `<a id="status">` at :210; `make test` = exit 0 (7/7)
- Review: 3 seats (GLM 5.3 / Kimi K3 / Grok 4.6). Kimi GO; GLM+Grok NO-GO converged on the false Git clause → delta 138c5d6 → both CUMULATIVE GO. Writer: Codex GPT-5.6 Sol

🤖 Generated with [Claude Code](https://claude.com/claude-code)