### PR TITLE
[consistency] B5: gitleaks + history-check via shared caller (#17)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,9 @@
+name: gitleaks
+on:
+  pull_request:
+permissions: {contents: read}
+concurrency: {group: 'gitleaks-${{ github.event.pull_request.number }}', cancel-in-progress: true}
+jobs:
+  gitleaks:
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-gitleaks.yml@ci-v1
+    permissions: {contents: read}

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -1,0 +1,9 @@
+name: History Check
+on:
+  pull_request:
+permissions: {contents: read}
+concurrency: {group: 'history-check-${{ github.event.pull_request.number }}', cancel-in-progress: true}
+jobs:
+  history-check:
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-history-check.yml@ci-v1
+    permissions: {contents: read}


### PR DESCRIPTION
Closes #17.

## What
Two Tier-0 secret/history gates as minimal callers of the family-dev-handbook reusable workflows, pinned to tag `ci-v1`:

- `.github/workflows/gitleaks.yml` → `reusable-gitleaks.yml@ci-v1`
- `.github/workflows/history-check.yml` → `reusable-history-check.yml@ci-v1`

No gate logic lives in this repo (B5 design — caller only). Form copied verbatim from the merged family-os callers (family-os#61 lane), which are the campaign's reference implementation.

## Files touched (WIP declaration match)
- `.github/workflows/gitleaks.yml` (new)
- `.github/workflows/history-check.yml` (new)

## Notes
- Trigger is `pull_request` only: the ci-v1 reusables hard-reject non-PR events (fail-closed, FP-6). Done-when interpretation recorded on #17.
- First real runs are expected on this PR itself (new workflows added in a PR run on that PR's pull_request event).

Campaign tracking: https://github.com/caty-ai/family-os/issues/56 (B5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)