### PR TITLE
[consistency] B10 follow-up: honest SKIPs for tar/xattr, trap finish, portable deep-case tmp (#24, #33)

### DIFF
--- a/tests/test_wt_snapshot.sh
+++ b/tests/test_wt_snapshot.sh
@@ -7,6 +7,7 @@ WT_SNAPSHOT="${ROOT}/bin/wt-snapshot"
 TMP_DIR=$(mktemp -d)
 PASS_COUNT=0
 FAIL_COUNT=0
+SKIP_COUNT=0
 RUN_STDOUT=""
 RUN_STDERR=""
 RUN_STATUS=0
@@ -21,7 +22,7 @@ cleanup() {
     rm -rf "${external_tmp_dir}"
   done
 }
-trap cleanup EXIT
+trap finish EXIT
 
 run_capture() {
   RUN_STDOUT="${TMP_DIR}/stdout.${RANDOM}"
@@ -58,11 +59,23 @@ record_fail() {
   printf 'FAIL %s: %s\n' "$1" "$2"
 }
 
+record_skip() {
+  SKIP_COUNT=$((SKIP_COUNT + 1))
+  printf 'SKIP %s: %s\n' "$1" "$2"
+}
+
 finish() {
-  printf '%d passed, %d failed\n' "${PASS_COUNT}" "${FAIL_COUNT}"
+  rc=$?
+  trap - EXIT
+  printf '%d passed, %d failed, %d skipped\n' "${PASS_COUNT}" "${FAIL_COUNT}" "${SKIP_COUNT}"
+  cleanup
   if [ "${FAIL_COUNT}" -ne 0 ]; then
     exit 1
   fi
+  if [ "${rc}" -ne 0 ]; then
+    exit "${rc}"
+  fi
+  exit 0
 }
 
 git_env() {
@@ -608,11 +621,19 @@ case_xattr_metadata_leak_is_scanned_raw() {
   local sandbox="${TMP_DIR}/${case_name}"
   local fixture main_repo worktree wrapper_dir real_tar refs_before refs_after objects_before objects_after
   local scan_cmd='grep -aFq FORBIDDEN-SECRET && exit 17 || exit 0'
+  if ! command -v xattr >/dev/null 2>&1; then
+    record_skip "${case_name}" "xattr not installed"
+    return 0
+  fi
+  real_tar=$(command -v tar || true)
+  if [ -z "${real_tar}" ]; then
+    record_skip "${case_name}" "tar not installed"
+    return 0
+  fi
   fixture=$(make_fixture_repo "${sandbox}")
   main_repo=$(printf '%s\n' "${fixture}" | sed -n '1p')
   worktree=$(printf '%s\n' "${fixture}" | sed -n '2p')
   wrapper_dir="${sandbox}/tar-wrapper"
-  real_tar=$(command -v tar)
   write_tar_interceptor "${wrapper_dir}"
   printf 'safe visible bytes\n' > "${worktree}/visible.txt"
   xattr -w secret.probe FORBIDDEN-SECRET "${worktree}/visible.txt"
@@ -638,6 +659,10 @@ case_xattr_metadata_leak_is_scanned_raw() {
 
 case_xattr_metadata_is_excluded_without_scanner() {
   local case_name="xattr-metadata-is-excluded-without-scanner"
+  if ! command -v xattr >/dev/null 2>&1; then
+    record_skip "${case_name}" "xattr not installed"
+    return 0
+  fi
   local sandbox="${TMP_DIR}/${case_name}"
   local fixture main_repo worktree ref payload expected actual extracted
   fixture=$(make_fixture_repo "${sandbox}")
@@ -681,7 +706,11 @@ case_payload_member_set_mismatch_is_fail_closed() {
   worktree=$(printf '%s\n' "${fixture}" | sed -n '2p')
   wrapper_dir="${sandbox}/tar-wrapper"
   inject_root="${sandbox}/inject-root"
-  real_tar=$(command -v tar)
+  real_tar=$(command -v tar || true)
+  if [ -z "${real_tar}" ]; then
+    record_skip "${case_name}" "tar not installed"
+    return 0
+  fi
   mkdir -p "${inject_root}"
   write_tar_interceptor "${wrapper_dir}"
   printf 'dirty bytes\n' > "${worktree}/visible.txt"
@@ -715,7 +744,11 @@ case_payload_member_type_mismatch_is_fail_closed() {
   main_repo=$(printf '%s\n' "${fixture}" | sed -n '1p')
   worktree=$(printf '%s\n' "${fixture}" | sed -n '2p')
   wrapper_dir="${sandbox}/tar-wrapper"
-  real_tar=$(command -v tar)
+  real_tar=$(command -v tar || true)
+  if [ -z "${real_tar}" ]; then
+    record_skip "${case_name}" "tar not installed"
+    return 0
+  fi
   type_flip_path="type-flip-target"
   write_tar_interceptor "${wrapper_dir}"
   mkdir -p "${worktree}/${type_flip_path}"
@@ -744,8 +777,13 @@ case_payload_member_type_mismatch_is_fail_closed() {
 case_deep_legal_tree_snapshots_and_restores() {
   local case_name="deep-legal-tree-snapshots-and-restores"
   local sandbox fixture main_repo worktree component deep_dir relative relative_file
+  local deep_tmp_base
   local ref restore_dir snapshot_status
-  sandbox=$(mktemp -d /private/tmp/context-kit-wt-snapshot-deep.XXXXXX)
+  deep_tmp_base=/tmp
+  if [ -d /private/tmp ]; then
+    deep_tmp_base=/private/tmp
+  fi
+  sandbox=$(mktemp -d "${deep_tmp_base}/context-kit-wt-snapshot-deep.XXXXXX")
   EXTERNAL_TMP_DIRS+=("${sandbox}")
   fixture=$(make_fixture_repo "${sandbox}")
   main_repo=$(printf '%s\n' "${fixture}" | sed -n '1p')
@@ -799,7 +837,11 @@ case_tar_capability_subset_keeps_both_backstops() {
   inject_root="${sandbox}/inject-root"
   tar_log="${sandbox}/tar.log"
   scan_log="${sandbox}/scan.log"
-  real_tar=$(command -v tar)
+  real_tar=$(command -v tar || true)
+  if [ -z "${real_tar}" ]; then
+    record_skip "${case_name}" "tar not installed"
+    return 0
+  fi
   mkdir -p "${inject_root}"
   write_tar_interceptor "${wrapper_dir}"
   printf 'dirty bytes\n' > "${worktree}/visible.txt"
@@ -1411,4 +1453,3 @@ case_empty_directories_alone_trigger_and_restore
 case_unborn_head_has_targeted_error
 case_restore_rejects_hostile_member_names_before_extract
 case_prune_lists_expired_refs_without_deleting
-finish


### PR DESCRIPTION
Closes #24. Closes #33.

## What (tests/test_wt_snapshot.sh only, +49/-8)
- 4× unguarded `command -v tar` → #19-shape guards (`|| true` + empty check + `record_skip` + return)
- 2 xattr cases guarded with `command -v xattr` (scope addition #1, evidence: ubuntu run 32349103307 died at :618 exit 127)
- `trap finish EXIT` unification: rc capture → untrap → single 3-field summary → cleanup on all paths → FAIL_COUNT→exit 1 → non-zero rc preserved; bare trailing `finish` removed
- deep-tree case `/private/tmp` hardcode → portable base (`/private/tmp` if present else `/tmp`), preserving the short real-path base the 951-byte relative path needs (scope addition #2 = #33, Kimi seat flip condition)

## Verification (local macOS + PATH-stub simulations)
- Normal: 29/29 PASS, `29 passed, 0 failed, 0 skipped`, exit 0 (re-run post-delta2 by orchestrator)
- tar hidden: 4 SKIP, all 29 case lines, summary once, exit 1 (honest fails from cases exercising tar via wt-snapshot)
- xattr hidden: 2 SKIP + 27 PASS, exit 0
- both hidden: 5 SKIP, 29 lines, summary once, no silent death

## Review
3 seats (GLM 5.3 / Kimi K3 / Grok 4.6) on the tar+xattr+finish diff: GLM GO, Grok GO, Kimi NO-GO with the /private/tmp flip condition → adopted as scope addition #2; delta re-confirmations in flight (recorded on #24).

## Expected CI on this PR
- ubuntu test: expected GREEN — first full-suite green on Linux (xattr cases SKIP honestly, deep case portable)
- macOS test: expected RED from the pre-existing wholesale wt_snapshot runner failure tracked as #30 (base-reproduced on run 32349103307, before any of this PR's changes) — unrelated to this diff; #30 lane follows

Campaign tracking: https://github.com/caty-ai/family-os/issues/56 (B10 派生)

🤖 Generated with [Claude Code](https://claude.com/claude-code)