### PR TITLE
[consistency] B6 follow-up: deterministic outer-timeout case on slow runners (#31)

### DIFF
--- a/tests/test_recall.sh
+++ b/tests/test_recall.sh
@@ -343,14 +343,14 @@ module = importlib.util.module_from_spec(spec)
 loader.exec_module(module)
 
 def slow_adapter(query, limit):
-    time.sleep(0.25)
+    time.sleep(2.0)
     return []
 
 module.build_layer_plans = lambda selected: ({"grep": slow_adapter}, {})
 started = time.monotonic()
 result = module.recall("probe", ["grep"], 1, timeout=0.01)
 elapsed = time.monotonic() - started
-assert elapsed < 0.15, elapsed
+assert elapsed < 1.0, elapsed
 assert result["exit_code"] == 1
 assert result["per_layer"]["grep"]["status"] == "error"
 assert result["per_layer"]["grep"]["reason"] == "timeout after 0.01s"


### PR DESCRIPTION
Refs #31 (close は macOS 緑 run URL の観測後に完了記録とともに行う — 枠だけ Done 禁止).

2-line change to `tests/test_recall.sh`: `slow_adapter` sleep 0.25→2.0, elapsed bound 0.15→1.0. The discrimination the case exists for (returning without awaiting the adapter: bound strictly below sleep) is preserved with ~14x headroom over the measured correct path (~0.07s); `timeout=0.01`, reason string, exit_code, status assertions untouched.

- Flake evidence: macos-latest run 32349103307 (FAIL outer-timeout-bounds-library-call; ubuntu and local pass)
- Review: 3 seats all GO (GLM 5.3 / Kimi K3 / Grok 4.6)
- Note: no test job runs on this PR (test-lint caller lands with #20); local verification + the #30 diagnostic PR's runs provide the execution evidence

Campaign tracking: https://github.com/caty-ai/family-os/issues/56 (B6 派生)

🤖 Generated with [Claude Code](https://claude.com/claude-code)