### PR TITLE
docs: npm version badge in the 4 READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,6 +7,7 @@
 ![context-kit — AI エージェント1体分のコンテキスト衛生キット](assets/readme/hero.png)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![npm](https://img.shields.io/npm/v/%40caty-ai%2Fcontext-kit?logo=npm&label=npm)](https://www.npmjs.com/package/@caty-ai/context-kit)
 ![python](https://img.shields.io/badge/python-3.9%2B-3776AB?logo=python&logoColor=white)
 ![node](https://img.shields.io/badge/node-18%2B_optional-lightgrey?logo=nodedotjs&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS_%7C_Linux-lightgrey)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ![context-kit — context hygiene kit for a single AI agent](assets/readme/hero.png)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![npm](https://img.shields.io/npm/v/%40caty-ai%2Fcontext-kit?logo=npm&label=npm)](https://www.npmjs.com/package/@caty-ai/context-kit)
 ![python](https://img.shields.io/badge/python-3.9%2B-3776AB?logo=python&logoColor=white)
 ![node](https://img.shields.io/badge/node-18%2B_optional-lightgrey?logo=nodedotjs&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS_%7C_Linux-lightgrey)

--- a/README.th.md
+++ b/README.th.md
@@ -7,6 +7,7 @@
 ![context-kit — ชุดอุปกรณ์ดูแลความสะอาดบริบทสำหรับ AI เอเจนต์หนึ่งตัว](assets/readme/hero.png)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![npm](https://img.shields.io/npm/v/%40caty-ai%2Fcontext-kit?logo=npm&label=npm)](https://www.npmjs.com/package/@caty-ai/context-kit)
 ![python](https://img.shields.io/badge/python-3.9%2B-3776AB?logo=python&logoColor=white)
 ![node](https://img.shields.io/badge/node-18%2B_optional-lightgrey?logo=nodedotjs&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS_%7C_Linux-lightgrey)

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,7 @@
 ![context-kit — 为单个 AI agent 打造的上下文卫生工具包](assets/readme/hero.png)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![npm](https://img.shields.io/npm/v/%40caty-ai%2Fcontext-kit?logo=npm&label=npm)](https://www.npmjs.com/package/@caty-ai/context-kit)
 ![python](https://img.shields.io/badge/python-3.9%2B-3776AB?logo=python&logoColor=white)
 ![node](https://img.shields.io/badge/node-18%2B_optional-lightgrey?logo=nodedotjs&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS_%7C_Linux-lightgrey)


### PR DESCRIPTION
Adds the npm badge (links to https://www.npmjs.com/package/@caty-ai/context-kit) right after the MIT badge in all four language READMEs. GitHub's sidebar Packages section only shows GitHub Packages, so the badge is the GitHub→npm pointer. Cosmetic docs-only change; generated regions untouched. Approved by Sho in-session (2026-08-23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)