### PR TITLE
chore: unify copyright holder to Sho Jikumaru

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Caty
+Copyright (c) 2026 Sho Jikumaru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -33,5 +33,6 @@
   "bugs": {
     "url": "https://github.com/caty-ai/context-kit/issues"
   },
+  "author": "Sho Jikumaru",
   "license": "MIT"
 }


### PR DESCRIPTION
Part of caty-ai/family-os#128

Unify the copyright holder to `Sho Jikumaru` (owner decision 2026-08-25). Product / org / project names using "Caty" are untouched; no `.github/workflows/**` files touched; LICENSE years unchanged.

## Changed files
- `LICENSE`
- `packages/npm/package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Completion record (L1-7)
- Candidate SHA (PR head): `69b29ddd48a3dba09ca87660e21851514d664c95`
- Done when (this repo's slice of family-os#128), measured 2026-08-25:
  - LICENSE holder line — PASS: `sed -n 3p LICENSE` @ head → `Copyright (c) 2026 Sho Jikumaru`
  - Residual old-holder lines — PASS: `git grep -E 'Copyright \(c\) 2026 (Caty|Shoji Kumaru)|© 2026 Caty|© Caty'` @ head → 0 hits
- package.json `author` = `Sho Jikumaru` — PASS: `packages/npm/package.json` (npm publish deferred to next regular release)
  - Years / product-name "Caty" / `.github/workflows/**` untouched — PASS: hunk-purity audit by all 3 review seats (record: caty-ai/family-os#128 issuecomment-5412434724)
- Declared file set vs diff — MATCH:
  - `LICENSE`
  - `packages/npm/package.json`
- Writer: Alpha (Claude Fable 5); commit author/committer `shojikumaru <184229851+shojikumaru@users.noreply.github.com>` (verified on head)
- Review: heterogeneous 3-seat panel GLM-5.3 / Kimi-K3 / Grok-4.6 — round 1 NO-GO (single converged MAJOR: persona-engine yearless footers) → delta `830db60` (persona-engine only) → **cumulative GO 3/3** bound to the per-repo HEADs incl. this SHA. No self-approve; writer is seat-disjoint.
- CI: green at record time (risk-review-gate human label pending where noted in #128)
- release: deferred — this change rides the repo's next regular release (owner decision recorded in family-os#128; no release forced for a copyright-holder text change). Exit trigger: next `vX.Y.Z` release of this repo.
- previous release: unchanged by this lane (no tag created or moved)
