### PR TITLE
WSL2: lg slug LC_ALL=C, xattr tests Linux path, docs reconciliation (#50)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/README.ja.md
+++ b/README.ja.md
@@ -109,6 +109,7 @@ flowchart LR
 | --- | --- |
 | macOS | ✅ system bsdtar を使う `wt-snapshot` を含め検証済み |
 | Linux | ✅ CI で検証済み（ubuntu-latest）。`wt-snapshot` は local tar option を capability-probe し、未対応の metadata suppression を明示する |
+| WSL2（Ubuntu） | ✅ Linux として動作 — リポジトリと scratch ディレクトリは ext4 側（`~` 配下など）に置く。`/mnt/c`（drvfs）では `chmod` が no-op になり、0700/0600 のパーミッション保護を強制できない |
 | AI エージェント | Claude Code ✅ — hook はその hook 仕様が対象 |
 | Python | 3.9 以上（ほとんどの装備で必要） |
 | Node.js | 18 以上（安全ガード3本のうち2本だけで必要） |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Before installing, check what it runs on.
 | --- | --- |
 | macOS | ✅ tested, including `wt-snapshot` with the system bsdtar |
 | Linux | ✅ verified in CI (ubuntu-latest); `wt-snapshot` capability-probes local tar options and reports unsupported metadata suppression |
+| WSL2 (Ubuntu) | ✅ works as Linux — keep repos and scratch directories on ext4 (e.g. under `~`); on `/mnt/c` (drvfs) `chmod` is a no-op, so the kit's 0700/0600 permission hardening cannot be enforced there |
 | AI agent | Claude Code ✅ — the hooks target its hook spec |
 | Python | 3.9 or newer, required by most pieces |
 | Node.js | 18 or newer, only for two of the three safety guards |

--- a/README.th.md
+++ b/README.th.md
@@ -109,6 +109,7 @@ flowchart LR
 | --- | --- |
 | macOS | ✅ ทดสอบแล้ว รวมถึง `wt-snapshot` ที่ใช้ system bsdtar |
 | Linux | ✅ ตรวจสอบแล้วผ่าน CI (ubuntu-latest); `wt-snapshot` จะตรวจ capability ของ local tar และแจ้ง metadata suppression ที่ไม่รองรับอย่างชัดเจน |
+| WSL2 (Ubuntu) | ✅ ทำงานแบบ Linux — เก็บ repo และไดเรกทอรี scratch ไว้บน ext4 (เช่นใต้ `~`); บน `/mnt/c` (drvfs) คำสั่ง `chmod` เป็น no-op ทำให้การบังคับสิทธิ์ 0700/0600 ของชุดเครื่องมือใช้ไม่ได้ |
 | AI เอเจนต์ | Claude Code ✅ — hook ออกแบบมาตาม hook spec ของมันโดยเฉพาะ |
 | Python | 3.9 ขึ้นไป จำเป็นสำหรับอุปกรณ์ส่วนใหญ่ |
 | Node.js | 18 ขึ้นไป ใช้เฉพาะการ์ดความปลอดภัย 2 ใน 3 ตัว |

--- a/README.zh.md
+++ b/README.zh.md
@@ -109,6 +109,7 @@ flowchart LR
 | --- | --- |
 | macOS | ✅ 已测试，包括使用系统 bsdtar 的 `wt-snapshot` |
 | Linux | ✅ 已通过 CI 验证（ubuntu-latest）；`wt-snapshot` 会探测本地 tar 选项，并明确报告不支持的 metadata suppression |
+| WSL2（Ubuntu） | ✅ 按 Linux 方式运行 — 请把仓库和 scratch 目录放在 ext4 侧（如 `~` 下）；在 `/mnt/c`（drvfs）上 `chmod` 是 no-op，0700/0600 权限加固无法生效 |
 | AI agent | Claude Code ✅ — hook 是针对它的 hook 规范设计的 |
 | Python | 3.9 及以上，大多数装备都需要 |
 | Node.js | 18 及以上，三道安全防线中有两道需要 |

--- a/bin/lg
+++ b/bin/lg
@@ -75,7 +75,7 @@ else
   EXPIRES=$(date -d "+${TTL_DAYS} days" "+%Y-%m-%dT%H:%M:%S")
 fi
 
-CMD_SLUG=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-32)
+CMD_SLUG=$(printf '%s' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr -c 'a-z0-9' '-' | LC_ALL=C sed 's/--*/-/g; s/^-//; s/-$//' | LC_ALL=C cut -c1-32)
 [ -z "$CMD_SLUG" ] && CMD_SLUG="cmd"
 
 SCRATCH_FILE="${SCRATCH_ROOT}/scratch-${TS}-${CMD_SLUG}.md"

--- a/docs/brief-validator.md
+++ b/docs/brief-validator.md
@@ -16,6 +16,7 @@ The hook blocks an incomplete substantial prompt with exit code `2`. Claude Code
 
 - `python3 >= 3.9` must be available to Claude Code.
 - On macOS, if `python3` is missing because Command Line Tools are not installed yet, `xcode-select --install` is the usual first step.
+- On Linux (including WSL2), install it with your package manager, e.g. `sudo apt install python3` on Debian/Ubuntu.
 
 ## Install
 

--- a/docs/lg.md
+++ b/docs/lg.md
@@ -10,6 +10,7 @@ This exists because a reactive `PostToolUse` hook cannot replace the standard to
 
 - `python3 >= 3.9` must be available to Claude Code.
 - On macOS, if `python3` is missing because Command Line Tools are not installed yet, `xcode-select --install` is the usual first step.
+- On Linux (including WSL2), install it with your package manager, e.g. `sudo apt install python3` on Debian/Ubuntu.
 
 ## Install
 
@@ -113,7 +114,7 @@ Fallback rules:
 
 Each scratch file includes `createdAt` and `expiresAt` metadata, and the default convention is a 7-day TTL through `LG_TTL_DAYS`.
 
-Scratch cleanup is intentionally user-owned. Use your own cron job or launchd task to remove expired files on your schedule.
+Scratch cleanup is intentionally user-owned. Use your own cron job or launchd task to remove expired files on your schedule. On WSL2, note that cron does not run by default — enable it (or systemd timers, via `systemd=true` in `/etc/wsl.conf`) or schedule the cleanup from Windows Task Scheduler.
 
 On scratch failure, large outputs can leave mode `0600` `lg.XXXXXX` temp files in `${TMPDIR:-/tmp}`; remove ones older than seven days with `find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'lg.*' -mtime +7 -delete`.
 

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -101,7 +101,7 @@
 | `CK_WTSNAP_IDENT` | すべての git 呼び出しに使う任意の identity。ユーザーの git config を読まず、author / committer 環境変数へ展開して使う | 組み込みのツール identity |
 | `CK_WTSNAP_TTL_DAYS` | `wt-snapshot prune` が期限切れ ref を一覧表示する際のしきい値日数。`prune` は一覧表示のみで、削除はしない | `30` |
 
-capture は invocation ごとに local `tar` を1回 capability-probe します。未対応の metadata-suppression option は明示的な警告付きで除外します。test archive を作成・検査できず構成を確定できない probe は、pack 前に `tar capability probe failed: ...` と exit `70` で中断します。このツールの Linux / GNU tar path は未検証です。
+capture は invocation ごとに local `tar` を1回 capability-probe します。未対応の metadata-suppression option は明示的な警告付きで除外します。test archive を作成・検査できず構成を確定できない probe は、pack 前に `tar capability probe failed: ...` と exit `70` で中断します。Linux / GNU tar path は CI（ubuntu-latest）で実走しています。
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -101,7 +101,7 @@ Export hook-related variables from the shell, launcher, or app wrapper that star
 | `CK_WTSNAP_IDENT` | Optional git identity for snapshot git invocations. The tool expands it into author and committer env vars instead of reading user git config | built-in tool identity |
 | `CK_WTSNAP_TTL_DAYS` | Age threshold used by `wt-snapshot prune` when listing expired snapshot refs. The command only lists; it never deletes | `30` |
 
-Capture capability-probes the local `tar` once per invocation. Unsupported metadata-suppression options are omitted with an explicit warning; a probe that cannot create and inspect its test archive fails before packing with `tar capability probe failed: ...` and exit `70`. Linux/GNU tar remains unverified for this tool.
+Capture capability-probes the local `tar` once per invocation. Unsupported metadata-suppression options are omitted with an explicit warning; a probe that cannot create and inspect its test archive fails before packing with `tar capability probe failed: ...` and exit `70`. The Linux/GNU tar path is exercised by CI (ubuntu-latest).
 
 ---
 

--- a/docs/scratch-persist.md
+++ b/docs/scratch-persist.md
@@ -10,6 +10,7 @@ A `PostToolUse` hook cannot replace the tool response that already entered conve
 
 - `python3 >= 3.9` must be available to Claude Code.
 - On macOS, if `python3` is missing because Command Line Tools are not installed yet, `xcode-select --install` is the usual first step.
+- On Linux (including WSL2), install it with your package manager, e.g. `sudo apt install python3` on Debian/Ubuntu.
 
 ## Install
 

--- a/docs/wt-snapshot.ja.md
+++ b/docs/wt-snapshot.ja.md
@@ -67,7 +67,7 @@ wt-snapshot prune
 
 ## tar 要件
 
-capture には、このツールが使う archive の作成・一覧・展開ができる local `tar` が必要です。Linux / GNU tar での `wt-snapshot` は、まだ実機検証していません。
+capture には、このツールが使う archive の作成・一覧・展開ができる local `tar` が必要です。macOS（bsdtar）と Linux / GNU tar の両経路は CI（ubuntu-latest がフルテストスイートを実行）で実走しています。README の対応表も参照してください。
 
 各 capture invocation の開始時に、`wt-snapshot` は小さな test archive を作成・検査し、続いて `--no-mac-metadata`、`--no-xattrs`、`--no-acls`、`--no-fflags` を1つずつ probe します。以降の tar command には、受理された suppression option だけを渡します。未対応 option は stderr の `tar metadata suppression unavailable: ...` で明示し、対応済み subset で capture を続行しますが、設定済み raw-archive scan と厳密な member-set verification は必須のままです。基礎 archive の作成・検証に失敗して安全な構成を確定できない場合は、pack 前に `tar capability probe failed: ...` と exit `70` で中断します。
 

--- a/docs/wt-snapshot.ja.md
+++ b/docs/wt-snapshot.ja.md
@@ -67,7 +67,7 @@ wt-snapshot prune
 
 ## tar 要件
 
-capture には、このツールが使う archive の作成・一覧・展開ができる local `tar` が必要です。macOS（bsdtar）と Linux / GNU tar の両経路は CI（ubuntu-latest がフルテストスイートを実行）で実走しています。README の対応表も参照してください。
+capture には、このツールが使う archive の作成・一覧・展開ができる local `tar` が必要です。CI は両経路を実走します: macOS ジョブが bsdtar を、ubuntu-latest ジョブが GNU tar を、それぞれフルテストスイートでカバーします。xattr metadata のセキュリティテストはさらに xattr ツール（macOS は `xattr`・Linux は `attr` パッケージの `setfattr`/`getfattr`）を必要とし、無い環境では loud skip として明示報告されます。README の対応表も参照してください。
 
 各 capture invocation の開始時に、`wt-snapshot` は小さな test archive を作成・検査し、続いて `--no-mac-metadata`、`--no-xattrs`、`--no-acls`、`--no-fflags` を1つずつ probe します。以降の tar command には、受理された suppression option だけを渡します。未対応 option は stderr の `tar metadata suppression unavailable: ...` で明示し、対応済み subset で capture を続行しますが、設定済み raw-archive scan と厳密な member-set verification は必須のままです。基礎 archive の作成・検証に失敗して安全な構成を確定できない場合は、pack 前に `tar capability probe failed: ...` と exit `70` で中断します。
 

--- a/docs/wt-snapshot.md
+++ b/docs/wt-snapshot.md
@@ -67,7 +67,7 @@ wt-snapshot prune
 
 ## Tar requirements
 
-Capture requires a local `tar` that can create, list, and extract the archives used by this tool. Both the macOS (bsdtar) and Linux/GNU tar paths are exercised by CI (ubuntu-latest runs the full test suite); see the README support table.
+Capture requires a local `tar` that can create, list, and extract the archives used by this tool. CI exercises both paths: the macOS job covers bsdtar and the ubuntu-latest job covers GNU tar, each running the full test suite. The xattr metadata security cases additionally need an xattr tool (`xattr` on macOS; `setfattr`/`getfattr` from the `attr` package on Linux) and report a loud skip when none is present. See the README support table.
 
 At the start of each capture invocation, `wt-snapshot` creates and inspects a trivial test archive, then probes `--no-mac-metadata`, `--no-xattrs`, `--no-acls`, and `--no-fflags` separately. Only the accepted suppression options are passed to later tar commands. Unsupported options are reported on stderr as `tar metadata suppression unavailable: ...`; capture continues with the supported subset, while the configured raw-archive scan and strict member-set verification remain mandatory. If baseline archive creation or validation cannot establish the configuration, capture stops before packing with exit `70` and a `tar capability probe failed: ...` message.
 

--- a/docs/wt-snapshot.md
+++ b/docs/wt-snapshot.md
@@ -67,7 +67,7 @@ wt-snapshot prune
 
 ## Tar requirements
 
-Capture requires a local `tar` that can create, list, and extract the archives used by this tool. Linux/GNU tar has not yet been verified for `wt-snapshot`.
+Capture requires a local `tar` that can create, list, and extract the archives used by this tool. Both the macOS (bsdtar) and Linux/GNU tar paths are exercised by CI (ubuntu-latest runs the full test suite); see the README support table.
 
 At the start of each capture invocation, `wt-snapshot` creates and inspects a trivial test archive, then probes `--no-mac-metadata`, `--no-xattrs`, `--no-acls`, and `--no-fflags` separately. Only the accepted suppression options are passed to later tar commands. Unsupported options are reported on stderr as `tar metadata suppression unavailable: ...`; capture continues with the supported subset, while the configured raw-archive scan and strict member-set verification remain mandatory. If baseline archive creation or validation cannot establish the configuration, capture stops before packing with exit `70` and a `tar capability probe failed: ...` message.
 

--- a/tests/test_lg.sh
+++ b/tests/test_lg.sh
@@ -116,6 +116,32 @@ case_non_ascii_command_slug_is_byte_deterministic() {
   fi
 }
 
+case_invalid_utf8_command_slug_is_byte_deterministic() {
+  local case_name="invalid-utf8-command-slug-is-byte-deterministic"
+  local scratch_dir="${TMP_DIR}/scratch-invalid-utf8"
+  local scratch_file
+  local scratch_name
+  local actual_slug
+
+  run_capture env LC_ALL=C.UTF-8 CK_SCRATCH_DIR="${scratch_dir}" \
+    "${LG}" $'echoX\xffY'
+  scratch_file=$(scratch_path_from_footer "${RUN_STDOUT}")
+  scratch_name=${scratch_file##*/}
+  actual_slug=$(printf '%s\n' "${scratch_name}" | sed -n \
+    's/^scratch-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-\(.*\)\.md$/\1/p')
+
+  if [ "${RUN_STATUS}" = "127" ] &&
+     grep -Fq '[lg] full output preserved:' "${RUN_STDOUT}" &&
+     [ -n "${scratch_file}" ] &&
+     [ -f "${scratch_file}" ] &&
+     [ "${actual_slug}" = "echox-y" ] &&
+     ! grep -Fq 'Illegal byte sequence' "${RUN_STDERR}"; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected exit 127, an echox-y scratch slug and file, and no illegal-byte stderr; got status ${RUN_STATUS} and slug '${actual_slug}'"
+  fi
+}
+
 case_large_preview() {
   local case_name="large-preview-200-lines"
   local scratch_dir="${TMP_DIR}/scratch-preview"
@@ -331,6 +357,7 @@ case_read_only_dir_root_skip() {
 case_usage
 case_small_full_temp_scratch
 case_non_ascii_command_slug_is_byte_deterministic
+case_invalid_utf8_command_slug_is_byte_deterministic
 case_large_preview
 case_invalid_numeric_defaults
 case_env_preview_override

--- a/tests/test_lg.sh
+++ b/tests/test_lg.sh
@@ -44,11 +44,11 @@ finish() {
 }
 
 scratch_path_from_footer() {
-  sed -n 's|^\[lg\] full output preserved: \(.*\) (TTL .*|\1|p' "$1"
+  LC_ALL=C sed -n 's|^\[lg\] full output preserved: \(.*\) (TTL .*|\1|p' "$1"
 }
 
 temp_path_from_marker() {
-  sed -n 's|^... \[[0-9][0-9]* lines omitted / [0-9][0-9]* bytes - scratch unavailable, full output temp: \(.*\)\] ...$|\1|p' "$1"
+  LC_ALL=C sed -n 's|^... \[[0-9][0-9]* lines omitted / [0-9][0-9]* bytes - scratch unavailable, full output temp: \(.*\)\] ...$|\1|p' "$1"
 }
 
 dir_mode() {
@@ -102,7 +102,7 @@ case_non_ascii_command_slug_is_byte_deterministic() {
     "${LG}" 'echo こんにちは'
   scratch_file=$(scratch_path_from_footer "${RUN_STDOUT}")
   scratch_name=${scratch_file##*/}
-  actual_slug=$(printf '%s\n' "${scratch_name}" | sed -n \
+  actual_slug=$(printf '%s\n' "${scratch_name}" | LC_ALL=C sed -n \
     's/^scratch-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-\(.*\)\.md$/\1/p')
 
   if [ "${RUN_STATUS}" = "0" ] &&
@@ -127,7 +127,7 @@ case_invalid_utf8_command_slug_is_byte_deterministic() {
     "${LG}" $'echoX\xffY'
   scratch_file=$(scratch_path_from_footer "${RUN_STDOUT}")
   scratch_name=${scratch_file##*/}
-  actual_slug=$(printf '%s\n' "${scratch_name}" | sed -n \
+  actual_slug=$(printf '%s\n' "${scratch_name}" | LC_ALL=C sed -n \
     's/^scratch-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-\(.*\)\.md$/\1/p')
 
   if [ "${RUN_STATUS}" = "127" ] &&

--- a/tests/test_lg.sh
+++ b/tests/test_lg.sh
@@ -85,6 +85,37 @@ case_small_full_temp_scratch() {
   fi
 }
 
+case_non_ascii_command_slug_is_byte_deterministic() {
+  local case_name="non-ascii-command-slug-is-byte-deterministic"
+  local command_dir="${TMP_DIR}/non-ascii-command-bin"
+  local command_path="${command_dir}/echo こんにちは"
+  local scratch_dir="${TMP_DIR}/scratch-non-ascii"
+  local scratch_file
+  local scratch_name
+  local actual_slug
+
+  mkdir -p "${command_dir}"
+  printf '#!/bin/sh\nprintf "non-ascii-command-ok\\n"\n' > "${command_path}"
+  chmod +x "${command_path}"
+
+  run_capture env PATH="${command_dir}:${PATH}" CK_SCRATCH_DIR="${scratch_dir}" \
+    "${LG}" 'echo こんにちは'
+  scratch_file=$(scratch_path_from_footer "${RUN_STDOUT}")
+  scratch_name=${scratch_file##*/}
+  actual_slug=$(printf '%s\n' "${scratch_name}" | sed -n \
+    's/^scratch-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-\(.*\)\.md$/\1/p')
+
+  if [ "${RUN_STATUS}" = "0" ] &&
+     grep -Fq 'non-ascii-command-ok' "${RUN_STDOUT}" &&
+     [ -n "${scratch_file}" ] &&
+     [ -f "${scratch_file}" ] &&
+     [ "${actual_slug}" = "echo" ]; then
+    record_pass "${case_name}"
+  else
+    record_fail "${case_name}" "expected a successful command and deterministic echo scratch slug, got '${actual_slug}'"
+  fi
+}
+
 case_large_preview() {
   local case_name="large-preview-200-lines"
   local scratch_dir="${TMP_DIR}/scratch-preview"
@@ -299,6 +330,7 @@ case_read_only_dir_root_skip() {
 
 case_usage
 case_small_full_temp_scratch
+case_non_ascii_command_slug_is_byte_deterministic
 case_large_preview
 case_invalid_numeric_defaults
 case_env_preview_override

--- a/tests/test_wt_snapshot.sh
+++ b/tests/test_wt_snapshot.sh
@@ -124,7 +124,7 @@ xattr_set() {
   local value="$2"
   local file="$3"
 
-  if command -v xattr >/dev/null 2>&1; then
+  if [ "$(uname -s)" = "Darwin" ]; then
     xattr -w "${name}" "${value}" "${file}"
   else
     # Linux user attributes require the user. namespace; macOS keeps the bare name.
@@ -136,7 +136,7 @@ xattr_probe() {
   local name="$1"
   local file="$2"
 
-  if command -v xattr >/dev/null 2>&1; then
+  if [ "$(uname -s)" = "Darwin" ]; then
     xattr -p "${name}" "${file}"
   else
     getfattr -n "user.${name}" --only-values "${file}"
@@ -678,13 +678,20 @@ case_xattr_metadata_leak_is_scanned_raw() {
   local sandbox="${TMP_DIR}/${case_name}"
   local fixture main_repo worktree wrapper_dir real_tar refs_before refs_after objects_before objects_after
   local scan_cmd='grep -aFq FORBIDDEN-SECRET && exit 17 || exit 0'
-  if ! command -v xattr >/dev/null 2>&1 && ! command -v setfattr >/dev/null 2>&1; then
-    record_skip "${case_name}" "no xattr tool (xattr/setfattr) installed — security coverage skipped"
-    return 0
-  fi
-  if ! command -v xattr >/dev/null 2>&1 && ! command -v getfattr >/dev/null 2>&1; then
-    record_fail "${case_name}" "setfattr is installed but getfattr is unavailable, so metadata absence cannot be verified"
-    return 0
+  if [ "$(uname -s)" = "Darwin" ]; then
+    if ! command -v xattr >/dev/null 2>&1; then
+      record_skip "${case_name}" "no xattr tool (xattr) installed — security coverage skipped"
+      return 0
+    fi
+  else
+    if ! command -v setfattr >/dev/null 2>&1; then
+      record_skip "${case_name}" "no xattr tool (setfattr) installed — security coverage skipped"
+      return 0
+    fi
+    if ! command -v getfattr >/dev/null 2>&1; then
+      record_fail "${case_name}" "setfattr is installed but getfattr is unavailable, so metadata absence cannot be verified"
+      return 0
+    fi
   fi
   real_tar=$(command -v tar || true)
   if [ -z "${real_tar}" ]; then
@@ -724,13 +731,20 @@ case_xattr_metadata_leak_is_scanned_raw() {
 
 case_xattr_metadata_is_excluded_without_scanner() {
   local case_name="xattr-metadata-is-excluded-without-scanner"
-  if ! command -v xattr >/dev/null 2>&1 && ! command -v setfattr >/dev/null 2>&1; then
-    record_skip "${case_name}" "no xattr tool (xattr/setfattr) installed — security coverage skipped"
-    return 0
-  fi
-  if ! command -v xattr >/dev/null 2>&1 && ! command -v getfattr >/dev/null 2>&1; then
-    record_fail "${case_name}" "setfattr is installed but getfattr is unavailable, so metadata absence cannot be verified"
-    return 0
+  if [ "$(uname -s)" = "Darwin" ]; then
+    if ! command -v xattr >/dev/null 2>&1; then
+      record_skip "${case_name}" "no xattr tool (xattr) installed — security coverage skipped"
+      return 0
+    fi
+  else
+    if ! command -v setfattr >/dev/null 2>&1; then
+      record_skip "${case_name}" "no xattr tool (setfattr) installed — security coverage skipped"
+      return 0
+    fi
+    if ! command -v getfattr >/dev/null 2>&1; then
+      record_fail "${case_name}" "setfattr is installed but getfattr is unavailable, so metadata absence cannot be verified"
+      return 0
+    fi
   fi
   local sandbox="${TMP_DIR}/${case_name}"
   local fixture main_repo worktree ref payload expected actual extracted

--- a/tests/test_wt_snapshot.sh
+++ b/tests/test_wt_snapshot.sh
@@ -119,6 +119,47 @@ file_mtime() {
   fi
 }
 
+xattr_set() {
+  local name="$1"
+  local value="$2"
+  local file="$3"
+
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -w "${name}" "${value}" "${file}"
+  else
+    # Linux user attributes require the user. namespace; macOS keeps the bare name.
+    setfattr -n "user.${name}" -v "${value}" "${file}"
+  fi
+}
+
+xattr_probe() {
+  local name="$1"
+  local file="$2"
+
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -p "${name}" "${file}"
+  else
+    getfattr -n "user.${name}" --only-values "${file}"
+  fi
+}
+
+tar_extract_without_metadata() {
+  local archive="$1"
+  local destination="$2"
+  local flag=""
+  local suppression_flags=()
+
+  for flag in --no-mac-metadata --no-xattrs --no-acls --no-fflags; do
+    if COPYFILE_DISABLE=1 tar "${flag}" -tf "${archive}" >/dev/null 2>&1; then
+      suppression_flags+=("${flag}")
+    fi
+  done
+
+  COPYFILE_DISABLE=1 tar \
+    ${suppression_flags[@]+"${suppression_flags[@]}"} \
+    --no-same-owner -xpf "${archive}" -C "${destination}"
+}
+
 repo_index_path() {
   local repo="$1"
   local path
@@ -292,13 +333,19 @@ done
 
 if [ "${create}" -eq 1 ] && [ "${CK_TEST_TAR_MODE:-}" = "metadata-leak" ]; then
   filtered=()
+  metadata_flags=()
   for argument in "$@"; do
     case "${argument}" in
       --no-mac-metadata|--no-xattrs|--no-acls|--no-fflags) ;;
       *) filtered+=("${argument}") ;;
     esac
   done
-  env -u COPYFILE_DISABLE "${CK_TEST_REAL_TAR}" "${filtered[@]}"
+  if "${CK_TEST_REAL_TAR}" --version 2>/dev/null | grep -q 'GNU tar'; then
+    # GNU tar does not archive xattrs by default, so explicitly expose the leak path.
+    metadata_flags+=(--xattrs)
+  fi
+  env -u COPYFILE_DISABLE "${CK_TEST_REAL_TAR}" \
+    ${metadata_flags[@]+"${metadata_flags[@]}"} "${filtered[@]}"
   exit $?
 fi
 
@@ -631,8 +678,12 @@ case_xattr_metadata_leak_is_scanned_raw() {
   local sandbox="${TMP_DIR}/${case_name}"
   local fixture main_repo worktree wrapper_dir real_tar refs_before refs_after objects_before objects_after
   local scan_cmd='grep -aFq FORBIDDEN-SECRET && exit 17 || exit 0'
-  if ! command -v xattr >/dev/null 2>&1; then
-    record_skip "${case_name}" "xattr not installed"
+  if ! command -v xattr >/dev/null 2>&1 && ! command -v setfattr >/dev/null 2>&1; then
+    record_skip "${case_name}" "no xattr tool (xattr/setfattr) installed — security coverage skipped"
+    return 0
+  fi
+  if ! command -v xattr >/dev/null 2>&1 && ! command -v getfattr >/dev/null 2>&1; then
+    record_fail "${case_name}" "setfattr is installed but getfattr is unavailable, so metadata absence cannot be verified"
     return 0
   fi
   real_tar=$(command -v tar || true)
@@ -646,7 +697,11 @@ case_xattr_metadata_leak_is_scanned_raw() {
   wrapper_dir="${sandbox}/tar-wrapper"
   write_tar_interceptor "${wrapper_dir}"
   printf 'safe visible bytes\n' > "${worktree}/visible.txt"
-  xattr -w secret.probe FORBIDDEN-SECRET "${worktree}/visible.txt"
+  if ! xattr_set secret.probe FORBIDDEN-SECRET "${worktree}/visible.txt" ||
+     ! xattr_probe secret.probe "${worktree}/visible.txt" >/dev/null 2>&1; then
+    record_fail "${case_name}" "failed to create and verify the xattr leak fixture"
+    return 0
+  fi
   refs_before=$(snapshot_refs "${main_repo}")
   objects_before=$(all_objects "${main_repo}")
 
@@ -669,8 +724,12 @@ case_xattr_metadata_leak_is_scanned_raw() {
 
 case_xattr_metadata_is_excluded_without_scanner() {
   local case_name="xattr-metadata-is-excluded-without-scanner"
-  if ! command -v xattr >/dev/null 2>&1; then
-    record_skip "${case_name}" "xattr not installed"
+  if ! command -v xattr >/dev/null 2>&1 && ! command -v setfattr >/dev/null 2>&1; then
+    record_skip "${case_name}" "no xattr tool (xattr/setfattr) installed — security coverage skipped"
+    return 0
+  fi
+  if ! command -v xattr >/dev/null 2>&1 && ! command -v getfattr >/dev/null 2>&1; then
+    record_fail "${case_name}" "setfattr is installed but getfattr is unavailable, so metadata absence cannot be verified"
     return 0
   fi
   local sandbox="${TMP_DIR}/${case_name}"
@@ -683,7 +742,11 @@ case_xattr_metadata_is_excluded_without_scanner() {
   actual="${sandbox}/actual.paths"
   extracted="${sandbox}/extracted"
   printf 'safe visible bytes\n' > "${worktree}/visible.txt"
-  xattr -w secret.probe FORBIDDEN-SECRET "${worktree}/visible.txt"
+  if ! xattr_set secret.probe FORBIDDEN-SECRET "${worktree}/visible.txt" ||
+     ! xattr_probe secret.probe "${worktree}/visible.txt" >/dev/null 2>&1; then
+    record_fail "${case_name}" "failed to create and verify the xattr exclusion fixture"
+    return 0
+  fi
 
   run_in_dir "${worktree}" "${WT_SNAPSHOT}"
   ref=$(snapshot_ref_for_prefix "${main_repo}" "$(basename "${worktree}")" | tail -n 1)
@@ -693,14 +756,16 @@ case_xattr_metadata_is_excluded_without_scanner() {
   fi
   git_setup -C "${main_repo}" show "${ref}:wt-snapshot.payload.tar" > "${payload}"
   mkdir -p "${extracted}"
-  COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs --no-acls --no-fflags \
-    --no-same-owner -xpf "${payload}" -C "${extracted}"
+  if ! tar_extract_without_metadata "${payload}" "${extracted}"; then
+    record_fail "${case_name}" "failed to extract the payload with locally supported metadata suppression flags"
+    return 0
+  fi
   write_tree_path_set "${worktree}" "${expected}"
   write_tree_path_set "${extracted}" "${actual}"
 
   if ! grep -aFq FORBIDDEN-SECRET "${payload}" &&
      cmp -s "${expected}" "${actual}" &&
-     ! xattr -p secret.probe "${extracted}/visible.txt" >/dev/null 2>&1; then
+     ! xattr_probe secret.probe "${extracted}/visible.txt" >/dev/null 2>&1; then
     record_pass "${case_name}"
   else
     record_fail "${case_name}" "payload members must equal the explicit path set and contain no xattr or AppleDouble metadata"


### PR DESCRIPTION
Closes #50 (parent: family-os#139)

## What

WSL2 portability fixes found by the 2026-08-25 cross-repo audit:

- `bin/lg`: slug pipeline now runs every stage under `LC_ALL=C` (consistent with `bin/wt-snapshot:282`) — byte-deterministic across BSD/GNU; ASCII slugs unchanged (33-command old-vs-new matrix: 0 mismatches, seat-verified).
- `tests/test_lg.sh`: `non-ascii-command-slug-is-byte-deterministic` pins the slug contract; `invalid-utf8-command-slug-is-byte-deterministic` pins the actual regression (red against the pre-fix pipeline: slug truncates to `echox` with `tr: Illegal byte sequence`; green now: `echox-y`, exit 127 preserved). Harness seds run under `LC_ALL=C` so older BSD sed on CI cannot abort on the raw 0xff.
- `tests/test_wt_snapshot.sh`: xattr metadata-leak cases run on Linux via `setfattr`/`getfattr`; helpers and guards dispatch on `uname -s` (immune to PyPI `xattr` CLI on Linux); extraction flags capability-probed; GNU-tar interceptor passes `--xattrs` to expose the leak path; SKIP only when no xattr tool exists, with a loud "security coverage skipped" reason. Assertions unchanged (exit 17 + no ref/object writes; member-set equality + metadata absence). Mutation-verified non-vacuous (seat evidence below).
- Docs reconciliation: `docs/wt-snapshot.md`/`.ja` + `docs/reference.md`/`.ja` no longer claim the Linux/GNU tar path is unverified; wt-snapshot docs attribute bsdtar to the macOS CI job and GNU tar to ubuntu-latest, and state the xattr-tool requirement + loud-skip behavior.
- README (en/ja/zh/th): support table gains a WSL2 row — works as Linux, keep repos/scratch on ext4 (`/mnt/c` drvfs `chmod` is a no-op so 0700/0600 hardening is unenforceable there).
- Per-tool docs (`lg.md`, `scratch-persist.md`, `brief-validator.md`): Linux python3 install path alongside xcode-select; `lg.md` gains a WSL2 cron caveat.
- `.gitattributes` (new): `* text=auto eol=lf`.

Follow-up filed: #52 (install `attr` on the ubuntu CI job so the Linux xattr security cases execute instead of loudly skipping — needs the shared reusable workflow, outside this PR's declared scope).

## Files touched (vs WIP declaration on #50)

bin/lg, tests/test_lg.sh, tests/test_wt_snapshot.sh, docs/wt-snapshot.md, docs/wt-snapshot.ja.md, docs/reference.md, docs/reference.ja.md, docs/lg.md, docs/scratch-persist.md, docs/brief-validator.md, README.md, README.ja.md, README.zh.md, README.th.md, .gitattributes — exactly the declared set (15/15). `git diff --stat origin/main...c8e9437` = these 15 files, nothing else (verified independently by all 3 seats).

## Completion record (L1-7) — FINAL

Candidate SHA: `c8e9437a85969f979b3747c0119c4408b6b65807` (= PR head)

Done when mapping (all evidence 2026-08-27):

1. **lg slug LC_ALL=C + non-ASCII test** — **PASS**. `bash tests/test_lg.sh` (local macOS): 13/13 PASS incl. both slug cases. Red-proof (Kimi seat, independent): pre-fix bin/lg in /tmp copy → `FAIL invalid-utf8-command-slug-is-byte-deterministic … got status 127 and slug 'echox'`; fixed lg → PASS.
2. **xattr tests Linux path / loud skip; pass vs skipped distinguishable** — **PASS**. macOS local + CI: `29 passed, 0 failed, 0 skipped` (cases execute). ubuntu container + attr (GLM/Kimi/Grok seats, independent): `29 passed, 0 failed, 0 skipped`. ubuntu container without attr: loud `SKIP …: no xattr tool … — security coverage skipped` + `27 passed, 0 failed, 2 skipped`. Mutation proof (GLM): deleting the GNU `--xattrs` interceptor branch → leak case FAILs (28/1/0) — coverage is non-vacuous.
3. **docs vs README reconciled** — **PASS**. Stale "unverified/未検証" claims removed repo-wide (Kimi: grep over all tracked files → no matches); single truth = CI-exercised, bsdtar/GNU correctly attributed per job.
4. **README WSL2 row + .gitattributes** — **PASS**. 4-language rows verified equivalent (Kimi). `.gitattributes` renormalization simulation on temp index → zero changes; no CRLF in tracked files (Kimi); `git ls-files --eol` → 0 non-LF text files (Alpha).
5. **Per-tool docs Linux python3 path** — **PASS**. All three xcode-select-mentioning docs gained the Linux line (Kimi: grep sweep confirms these are the only occurrences).
6. **make test green on ubuntu CI + local macOS** — **PASS**. Local macOS: `declared: 8, executed: 8 / passed: 8, failed: 0`. CI on c8e9437: test-lint / test (ubuntu) pass, test-lint / test-macos pass — see check runs on this PR (full check list green, run links in the checks tab). Intermediate red at e36e3a5 (test-macos: older BSD sed aborted on the 0xff in harness parsing) was root-caused and fixed by the harness-only commit c8e9437; ubuntu was green at every SHA.

Implementer / reviewers (identities + heterogeneity, L1-3/L1-10): writer = Codex GPT-5.6 Sol (`codex exec --profile sol`; bin/lg, both test files, 2 delta rounds) + Alpha (Claude Fable 5; docs/README/.gitattributes; orchestrator — NOT counted as a review seat). Review seats (heterogeneous 3, loom-seats selection GO, panel = glm-5.3 / kimi-k3 / grok-4.6, all distinct lineages from each other and from both writers):

| Seat | requested | actual (self-reported) | R1 (7ca8ed9) | R2 delta (e36e3a5) | R3 micro (c8e9437) |
|---|---|---|---|---|---|
| GLM | glm-5.3 | GLM (Zhipu) | GO, 2 MINOR + 3 INFO (mutation-verified) | NO-GO for e36e3a5 (CI red; pre-verified c8e9437 locally 8/8) | GO (micro-out.md) |
| Kimi | kimi-k3 | Kimi (Moonshot) | GO, 3 MINOR + INFO | GO (red-proof re-run independently) | GO |
| Grok | grok-4.6 | Grok 4.6 (xAI) | GO, 3 MINOR (docker ubuntu ±attr verification) | GO | GO |

Convergent findings adopted: invalid-UTF-8 regression pin (3/3 seats), docs bsdtar/GNU attribution + xattr-tool clause (2 seats), uname-based helper dispatch (Kimi). Non-adopted: CI attr install (outside declared scope → Issue #52 with exit trigger). Review artifacts: seat out-files retained in session scratchpad; requested/actual recorded above. blocking findings after final round: 0.

CI status: all checks green on c8e9437 (gitleaks, history-check, pr-size, repo-state, risk-review-gate, test-lint lint/test/test-macos).

release: v0.3.2 (declared; annotated tag on the merge commit after Sho's approval; GitHub Release fulfilled via release-sync green run — npm publish is a separate manual workflow_dispatch decision, not implied by the tag)
previous release: v0.3.1 — fulfilled (annotated tag + GitHub Release exist, listed Latest; re-checked 2026-08-27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
