### PR TITLE
repo-state: pin v0.12.1 + secrets: inherit (app-authenticated stamp pushes)

### DIFF
--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   repo-state:
-    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.1
+    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.12.1
+    secrets: inherit
     with:
-      generator_ref: v0.11.1
+      generator_ref: v0.12.1


### PR DESCRIPTION
## Why

Follow-up to #48 (parent caty-ai/family-os#127). The v0.11.1 caller's `GITHUB_TOKEN` stamp push is blocked by required checks; family-os v0.12.1 (PR family-os#141, 3-seat GO + pre-merge live verification on sitter) authenticates the push as the org app `caty-repo-state-bot` via the ruleset's app-scoped bypass.

## What (3-line mechanical diff)

- `uses:` → `@v0.12.1`, `generator_ref: v0.12.1` (refs move together per canon), `secrets: inherit` added (passes this repo's `REPO_STATE_APP_ID`/`REPO_STATE_APP_PRIVATE_KEY`, already distributed).

## Verification

- Mechanism live-verified pre-merge on sitter: app push landed through the ruleset, committer identity preserved, loop guard skipped the follow-on run (family-os#140 comment-5429234031).
- Review: single heterogeneous delta seat over the whole bump batch (owner-approved lighter scheme for mechanical copies, family-os#127).

## Gate

Touches `.github/workflows/**` → owner risk-gate label (final batch). After merge: one `workflow_dispatch` heals this repo's status.json (branch: main + release fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)