### PR TITLE
ci(watchdog): add external-input caller (caty-ai/.github#61)

### DIFF
--- a/.github/workflows/external-input-caller.yml
+++ b/.github/workflows/external-input-caller.yml
@@ -1,0 +1,36 @@
+# Thin caller for the org-wide external-input watchdog (caty-ai/.github#61).
+# SECURITY: pull_request_target runs with secrets — never add checkout here.
+# discussion/discussion_comment are no-ops on repos without Discussions.
+# @main pin is a conscious trade (one fix reaches 13 repos); precondition:
+# caty-ai/.github main is merge-only via PR (see #61 for the record).
+name: external-input-caller
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  discussion:
+    types: [created]
+  discussion_comment:
+    types: [created]
+
+# Load-bearing: pull_request_target defaults to a WRITE token — this map
+# denies contents and caps the callee. Do not delete it.
+permissions:
+  contents: none
+  issues: write
+  pull-requests: write
+
+jobs:
+  watch:
+    uses: caty-ai/.github/.github/workflows/external-input-watch.yml@main
+    secrets:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
Rollout of the org external-input watchdog (caty-ai/.github#61; reusable workflow v0.7.0, merged via caty-ai/.github#62 after 5-seat heterogeneous review — r1/delta/micro records on that PR).

**This PR**: adds `.github/workflows/external-input-caller.yml` only — a verbatim, byte-identical copy of the reviewed template.
- template sha256 (caty-ai/.github@main): `bd260663bec85a6d56dda42960e6f8dcd1c84647f324830f531a3c79b51f32c6`
- this file sha256: `bd260663bec85a6d56dda42960e6f8dcd1c84647f324830f531a3c79b51f32c6`
- match: yes

Detection: labels `external-input` + Telegram notification for non-family issues/comments/PRs/reviews/discussions. Secrets `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` are already set on this repo (2026-08-29). No checkout, `contents: none`, explicit two-secret mapping.

**Completion record (L1-7, per-repo rollout scope)**
- Done when: caller live on default branch → PASS on merge (this diff is the entire change).
- File set: exactly 1 file (matches the prediction on caty-ai/.github#61).
- Review: the file is byte-identical to the 5-seat-reviewed template (sha256 above = machine evidence); panel record = caty-ai/.github#62. Writer of this PR = Alpha; reviewers = that heterogeneous panel (identity link via sha256).
- CI: this repo's checks must be green before merge (enforced in phase 2).
- release: N/A (type ③ — CI/ops wiring only; no product behavior, API, or distributed artifact of this repo changes)
- previous release: not applicable to this record type (N/A lane; no shipping-equivalent chain consumed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)