### PR TITLE
ci: install attr on the ubuntu test job so xattr security cases run (#52)

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -5,7 +5,17 @@ permissions: {contents: read}
 concurrency: {group: 'test-lint-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:
   test-lint:
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@ci-v1
+    # TEMP PIN (context-kit#52): the pre_test_setup_ubuntu input lands in handbook#101 / PR #145.
+    # Pinned to the feature branch only to get a dynamic green before the upstream merges;
+    # re-pinned to the SemVer tag once it exists (ci-v1 advance is an owner decision, handbook#116).
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@feat/101-test-lint-node-setup-inputs
     permissions: {contents: read}
     with:
       run_macos: true
+      # context-kit#52: GitHub's ubuntu image does not ship `attr`, so the Linux xattr
+      # security cases (xattr-metadata-leak-is-scanned-raw / xattr-metadata-is-excluded-without-scanner)
+      # would loudly SKIP. Install it so they execute. macOS has `xattr` built in.
+      pre_test_setup_ubuntu: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends attr
+        command -v setfattr && command -v getfattr

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -5,10 +5,11 @@ permissions: {contents: read}
 concurrency: {group: 'test-lint-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:
   test-lint:
-    # TEMP PIN (context-kit#52): the pre_test_setup_ubuntu input lands in handbook#101 / PR #145.
-    # Pinned to the feature branch only to get a dynamic green before the upstream merges;
-    # re-pinned to the SemVer tag once it exists (ci-v1 advance is an owner decision, handbook#116).
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@feat/101-test-lint-node-setup-inputs
+    # Pinned to the SemVer tag that carries the pre_test_setup_ubuntu input (handbook#101 / v0.23.0).
+    # The moving ci-v1 tag does not carry it yet (advance = owner decision, handbook#116); switch back
+    # to @ci-v1 only after ci-v1 >= v0.23.0. Note: an input the reusable does not declare only WARNS,
+    # so a wrong pin would silently drop the attr install and the xattr cases would loudly SKIP again.
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@v0.23.0
     permissions: {contents: read}
     with:
       run_macos: true
@@ -18,4 +19,6 @@ jobs:
       pre_test_setup_ubuntu: |
         sudo apt-get update -qq
         sudo apt-get install -y --no-install-recommends attr
-        command -v setfattr && command -v getfattr
+        # one command per line: under set -e an `a && b` list only fails the step when it is the last line
+        command -v setfattr
+        command -v getfattr

--- a/README.ja.md
+++ b/README.ja.md
@@ -235,7 +235,7 @@ make test
 
 ## Project status
 
-- **CI:** 稼働中。gitleaks・history-check・test + lint（ubuntu と macOS）・pr-size・risk-review gate が、家族共通の reusable workflow（`ci-v1` ピン）の caller としてすべての PR で走ります。上のバッジは test-lint workflow が塗っています。
+- **CI:** 稼働中。gitleaks・history-check・test + lint（ubuntu と macOS）・pr-size・risk-review gate が、家族共通の reusable workflow（`ci-v1` ピン。test-lint だけは `ci-v1` が追いつくまで `@v0.23.0` — caty-ai/family-dev-handbook#116）の caller としてすべての PR で走ります。上のバッジは test-lint workflow が塗っています。
 - **検証済み環境:** macOS（ローカル + CI ランナー）｜ Linux（CI ランナー、ubuntu-latest）。
 - **成熟度:** v0.2.0 で6番目の装備 `wt-snapshot` をリリースしました。インターフェースは今後も変わる可能性があります。
 - **既知の制限:** safety guard は意図的に fail-open です。guard が壊れてもエージェントをブロックしません。macOS-first ですが、`wt-snapshot` の Linux/GNU tar 経路は CI で実走検証されています。

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The details live in reader-specific docs, one level deeper.
 
 ## Project status
 
-- **CI:** Live. gitleaks, history-check, test + lint (ubuntu & macOS), pr-size, and the risk-review gate run on every PR as callers of the family reusable workflows (pinned `ci-v1`); the badge above is painted by the test-lint workflow.
+- **CI:** Live. gitleaks, history-check, test + lint (ubuntu & macOS), pr-size, and the risk-review gate run on every PR as callers of the family reusable workflows (pinned `ci-v1`; test-lint is on `@v0.23.0` until `ci-v1` advances past it — caty-ai/family-dev-handbook#116); the badge above is painted by the test-lint workflow.
 - **Verified environments:** macOS (local + CI runner) | Linux (CI runner, ubuntu-latest).
 - **Maturity:** v0.2.0 shipped the sixth piece, `wt-snapshot`. Interfaces may still move.
 - **Known limits:** Safety guards are fail-open by design: a broken guard never blocks the agent. The project is macOS-first; the Linux/GNU tar path of `wt-snapshot` is exercised by CI.

--- a/README.th.md
+++ b/README.th.md
@@ -235,7 +235,7 @@ make test
 
 ## Project status
 
-- **CI:** ใช้งานแล้ว gitleaks, history-check, test + lint (ubuntu และ macOS), pr-size และ risk-review gate ทำงานบนทุก PR ในฐานะ caller ของ family reusable workflow (ปักหมุด `ci-v1`) แบดจ์ด้านบนถูกทาสีโดย test-lint workflow
+- **CI:** ใช้งานแล้ว gitleaks, history-check, test + lint (ubuntu และ macOS), pr-size และ risk-review gate ทำงานบนทุก PR ในฐานะ caller ของ family reusable workflow (ปักหมุด `ci-v1`; test-lint ใช้ `@v0.23.0` จนกว่า `ci-v1` จะตามทัน — caty-ai/family-dev-handbook#116) แบดจ์ด้านบนถูกทาสีโดย test-lint workflow
 - **สภาพแวดล้อมที่ตรวจสอบแล้ว:** macOS (ในเครื่อง + CI runner) | Linux (CI runner, ubuntu-latest)
 - **ระดับความพร้อม:** v0.2.0 เปิดตัวอุปกรณ์ชิ้นที่หกคือ `wt-snapshot` อินเทอร์เฟซยังอาจเปลี่ยนแปลงได้
 - **ข้อจำกัดที่ทราบ:** safety guard ถูกออกแบบให้ fail-open การ์ดที่เสียจะไม่บล็อกเอเจนต์ โปรเจกต์นี้ให้ความสำคัญกับ macOS ก่อน โดยเส้นทาง Linux/GNU tar ของ `wt-snapshot` ได้รับการตรวจสอบจริงผ่าน CI แล้ว

--- a/README.zh.md
+++ b/README.zh.md
@@ -235,7 +235,7 @@ make test
 
 ## Project status
 
-- **CI:** 已上线。gitleaks、history-check、test + lint（ubuntu 与 macOS）、pr-size 以及 risk-review gate 作为家族共享 reusable workflow（固定 `ci-v1`）的 caller 在每个 PR 上运行；上方徽章由 test-lint workflow 绘制。
+- **CI:** 已上线。gitleaks、history-check、test + lint（ubuntu 与 macOS）、pr-size 以及 risk-review gate 作为家族共享 reusable workflow（固定 `ci-v1`；test-lint 在 `ci-v1` 跟上之前固定为 `@v0.23.0` — caty-ai/family-dev-handbook#116）的 caller 在每个 PR 上运行；上方徽章由 test-lint workflow 绘制。
 - **已验证环境:** macOS（本地 + CI runner）｜ Linux（CI runner，ubuntu-latest）。
 - **成熟度:** v0.2.0 发布了第六件装备 `wt-snapshot`。接口仍可能发生变化。
 - **已知限制:** safety guard 按设计采用 fail-open；不会因 guard 损坏而阻塞 agent。本项目以 macOS 为优先平台；`wt-snapshot` 的 Linux/GNU tar 路径已由 CI 实际运行验证。

--- a/docs/wt-snapshot.ja.md
+++ b/docs/wt-snapshot.ja.md
@@ -67,7 +67,7 @@ wt-snapshot prune
 
 ## tar 要件
 
-capture には、このツールが使う archive の作成・一覧・展開ができる local `tar` が必要です。CI は両経路を実走します: macOS ジョブが bsdtar を、ubuntu-latest ジョブが GNU tar を、それぞれフルテストスイートでカバーします。xattr metadata のセキュリティテストはさらに xattr ツール（macOS は `xattr`・Linux は `attr` パッケージの `setfattr`/`getfattr`）を必要とし、無い環境では loud skip として明示報告されます。README の対応表も参照してください。
+capture には、このツールが使う archive の作成・一覧・展開ができる local `tar` が必要です。CI は両経路を実走します: macOS ジョブが bsdtar を、ubuntu-latest ジョブが GNU tar を、それぞれフルテストスイートでカバーします。xattr metadata のセキュリティテストはさらに xattr ツール（macOS は `xattr`・Linux は `attr` パッケージの `setfattr`/`getfattr`）を必要とし、無い環境では loud skip として明示報告されます。ubuntu の CI ジョブはスイート実行前に `attr` をインストールする（`.github/workflows/test-lint.yml`）ため、これらのケースは CI の両レグで skip ではなく実行されます。README の対応表も参照してください。
 
 各 capture invocation の開始時に、`wt-snapshot` は小さな test archive を作成・検査し、続いて `--no-mac-metadata`、`--no-xattrs`、`--no-acls`、`--no-fflags` を1つずつ probe します。以降の tar command には、受理された suppression option だけを渡します。未対応 option は stderr の `tar metadata suppression unavailable: ...` で明示し、対応済み subset で capture を続行しますが、設定済み raw-archive scan と厳密な member-set verification は必須のままです。基礎 archive の作成・検証に失敗して安全な構成を確定できない場合は、pack 前に `tar capability probe failed: ...` と exit `70` で中断します。
 

--- a/docs/wt-snapshot.md
+++ b/docs/wt-snapshot.md
@@ -67,7 +67,7 @@ wt-snapshot prune
 
 ## Tar requirements
 
-Capture requires a local `tar` that can create, list, and extract the archives used by this tool. CI exercises both paths: the macOS job covers bsdtar and the ubuntu-latest job covers GNU tar, each running the full test suite. The xattr metadata security cases additionally need an xattr tool (`xattr` on macOS; `setfattr`/`getfattr` from the `attr` package on Linux) and report a loud skip when none is present. See the README support table.
+Capture requires a local `tar` that can create, list, and extract the archives used by this tool. CI exercises both paths: the macOS job covers bsdtar and the ubuntu-latest job covers GNU tar, each running the full test suite. The xattr metadata security cases additionally need an xattr tool (`xattr` on macOS; `setfattr`/`getfattr` from the `attr` package on Linux) and report a loud skip when none is present. The ubuntu CI job installs `attr` before running the suite (see `.github/workflows/test-lint.yml`), so those cases execute on both CI legs rather than skipping. See the README support table.
 
 At the start of each capture invocation, `wt-snapshot` creates and inspects a trivial test archive, then probes `--no-mac-metadata`, `--no-xattrs`, `--no-acls`, and `--no-fflags` separately. Only the accepted suppression options are passed to later tar commands. Unsupported options are reported on stderr as `tar metadata suppression unavailable: ...`; capture continues with the supported subset, while the configured raw-archive scan and strict member-set verification remain mandatory. If baseline archive creation or validation cannot establish the configuration, capture stops before packing with exit `70` and a `tar capability probe failed: ...` message.
 


### PR DESCRIPTION
Refs #52 (closed by the MERGED record, not by keyword). Upstream: caty-ai/family-dev-handbook#101 / PR caty-ai/family-dev-handbook#145 → released as **v0.23.0** (https://github.com/caty-ai/family-dev-handbook/releases/tag/v0.23.0).

## What

- `.github/workflows/test-lint.yml`: pin the shared reusable to `@v0.23.0` (the SemVer tag that carries the new `pre_test_setup_ubuntu` input) and pass a setup script that installs `attr` on the ubuntu test job, so the Linux xattr security cases (`xattr-metadata-leak-is-scanned-raw`, `xattr-metadata-is-excluded-without-scanner`) execute instead of loudly skipping. macOS has `xattr` built in, so no macOS setup.
- `docs/wt-snapshot.md` / `docs/wt-snapshot.ja.md`: one clause stating that ubuntu CI installs `attr` (Done when ③).
- `README.md` / `README.ja.md` / `README.zh.md` / `README.th.md` line 238: the "pinned `ci-v1`" clause now says test-lint is on `@v0.23.0` until `ci-v1` advances (handbook#116 — owner decision; this lane does not advance `ci-v1`).

## Files touched (L0-6)

- `.github/workflows/test-lint.yml`
- `docs/wt-snapshot.md`, `docs/wt-snapshot.ja.md`
- `README.md`, `README.ja.md`, `README.zh.md`, `README.th.md` (declared by WIP amendment on #52, 2026-09-04)

## Not in scope

- Flipping `require_suite_reconciliation: true` — CI half of #38, after that lane merges.
- Installing `rg` for the one remaining pre-existing skip in `test_recall.sh` (`colon-path-survives-rg-and-grep-fallback: rg not installed`) — same mechanism would work; separate decision.

## 完了記録 (Completion record)

candidate SHA: 3198bfd27c93ee9437a893f0692dce814bcf50fe
implementer: alpha (Claude Code / Fable 5.1) — direct edit (CI YAML + docs)
reviewer: GLM 5.3 (requested glm-5.3 / actual glm-5.3) / Kimi K3 (requested kimi-code/k3 / actual kimi-k3) / Grok 4.6 (requested grok-4.6 / actual grok-4.6) — heterogeneous 3, all different from the writer
identity check: 別モデル（writer=Fable 5.1 vs GLM / Kimi / Grok）
review rounds: r1 @4ae1704 (branch-pinned) = GLM GO-with-MINOR / Kimi GO-with-MINOR / Grok GO-with-MINOR — converged on "re-pin must verify the tag's semantics + fresh dynamic green", plus Kimi F2 (README ×4 pin clause) and Grok F2 (`command -v` one per line); all adopted in 3198bfd. delta @3198bfd = GLM GO (reusable blob at v0.23.0 byte-identical to reviewed 2c4b2db) / Kimi GO / Grok GO (1 NIT: whether an undeclared input warns or errors is doc-ambiguous; pin is the declaring tag either way). Ledger on #52.
CI: green for every mechanical check at 3198bfd (`test-lint / test` https://github.com/caty-ai/context-kit/actions/runs/33791123077/job/100767692410 pass; lint / test-macos / gitleaks / history-check / pr-size / repo-state pass). `risk-review-gate / risk-review-gate` is red by design until the roster human applies `risk-reviewed` for this head (`.github/workflows/` = gates category) — the human gate itself, not a T-4 exception; merge only after it turns green.
release: N/A（③ CI・開発環境の配線のみ。挙動・公開 API・配布物は変わらない。docs/README の追記は CI の事実を述べる1文で、利用者が従う規範ではない）
previous release: v0.3.3 → https://github.com/caty-ai/context-kit/releases/tag/v0.3.3（履行済み・Release 実在・Latest）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| The ubuntu test job has `attr` installed (via a reusable-workflow input for pre-test setup steps) | PASS | ubuntu job log @3198bfd（2026-09-04）: `Uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@refs/tags/v0.23.0` → `Setting up attr (1:2.5.2-1ubuntu0.1) ...` → `/usr/bin/setfattr` / `/usr/bin/getfattr`（setup script の `command -v` 出力） |
| test-lint ubuntu logs for a PR show `xattr-metadata-leak-is-scanned-raw` and `xattr-metadata-is-excluded-without-scanner` as PASS (not SKIP) | PASS | 同ログ: `PASS xattr-metadata-leak-is-scanned-raw` / `PASS xattr-metadata-is-excluded-without-scanner` / `29 passed, 0 failed, 0 skipped`（wt-snapshot スイート）。同じ結果を branch pin 時 @4ae1704 でも2回観測（run 33781650357 初回 + 再実行）。macOS レグも両ケース PASS（builtin `xattr`）|
| the wt-snapshot docs' xattr-tooling sentence still matches CI reality | PASS | `docs/wt-snapshot.md:70` / `.ja.md:70` に「ubuntu の CI ジョブはスイート実行前に `attr` をインストールする」を追記。3席が独立に CI ログと突合して一致を確認（2026-09-04） |

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...3198bfd:
```
 .github/workflows/test-lint.yml | 15 ++++++++++++++-
 README.ja.md                    |  2 +-
 README.md                       |  2 +-
 README.th.md                    |  2 +-
 README.zh.md                    |  2 +-
 docs/wt-snapshot.ja.md          |  2 +-
 docs/wt-snapshot.md             |  2 +-
 7 files changed, 20 insertions(+), 7 deletions(-)
```
宣言ファイル集合との差分: なし（README ×4 は #52 の WIP amendment で宣言済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
