### PR TITLE
Wire shellcheck into make lint + T-6 suite summary line (#38)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,23 +12,33 @@ lint:
 		echo "missing-dep: shellcheck" >&2; \
 		exit 127; \
 	fi; \
+	if ! command -v git >/dev/null 2>&1; then \
+		echo "missing-dep: git" >&2; \
+		exit 127; \
+	fi; \
 	files=(); \
-	while IFS= read -r file; do \
-		files+=("$$file"); \
-	done < <(git ls-files -- '*.sh'); \
-	while IFS= read -r file; do \
-		first_line=$$(LC_ALL=C sed -n '1p' "$$file"); \
-		if [[ "$$first_line" =~ ^\#\!.*[[:space:]/](bash|sh)([[:space:]]|$$) ]]; then \
-			seen=0; \
-			for listed in "$${files[@]}"; do \
-				if [ "$$listed" = "$$file" ]; then seen=1; break; fi; \
-			done; \
-			if [ "$$seen" -eq 0 ]; then files+=("$$file"); fi; \
-		fi; \
-	done < <(git ls-files -- bin hooks); \
+	sh_files=$$(git ls-files -- '*.sh') || { echo "lint: git ls-files failed" >&2; exit 1; }; \
+	discovered_files=$$(git ls-files -- bin hooks) || { echo "lint: git ls-files failed" >&2; exit 1; }; \
+	if [ -n "$$sh_files" ]; then \
+		while IFS= read -r file; do \
+			files+=("$$file"); \
+		done <<< "$$sh_files"; \
+	fi; \
+	if [ -n "$$discovered_files" ]; then \
+		while IFS= read -r file; do \
+			first_line=$$(LC_ALL=C sed -n '1p' "$$file"); \
+			if [[ "$$first_line" =~ ^\#\!.*[[:space:]/](bash|sh)([[:space:]]|$$) ]]; then \
+				seen=0; \
+				for listed in "$${files[@]}"; do \
+					if [ "$$listed" = "$$file" ]; then seen=1; break; fi; \
+				done; \
+				if [ "$$seen" -eq 0 ]; then files+=("$$file"); fi; \
+			fi; \
+		done <<< "$$discovered_files"; \
+	fi; \
 	if [ "$${#files[@]}" -eq 0 ]; then \
-		echo "lint: no shell scripts found"; \
-		exit 0; \
+		echo "lint: no shell scripts discovered — refusing to pass an empty lint (fail-closed)" >&2; \
+		exit 1; \
 	fi; \
 	printf 'shellcheck: %s\n' "$${files[@]}"; \
 	shellcheck --severity=warning --exclude=SC2155 "$${files[@]}"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,34 @@
 .PHONY: test lint
 
+SHELL := /bin/bash
+
 test:
 	bash tests/run.sh
 
-# lint is intentionally a no-op placeholder until a linter is adopted for
-# this repo. Replace this target once shellcheck (or similar) is wired in.
+# The SC2155 exclusion covers 12 pre-existing findings in `tests/test_safety_hooks.sh`.
+# #38 leaves that file untouched because #52 may edit it; remove the exclusion once it is clean.
 lint:
-	@echo "lint: no linter configured yet (placeholder)"
+	@if ! command -v shellcheck >/dev/null 2>&1; then \
+		echo "missing-dep: shellcheck" >&2; \
+		exit 127; \
+	fi; \
+	files=(); \
+	while IFS= read -r file; do \
+		files+=("$$file"); \
+	done < <(git ls-files -- '*.sh'); \
+	while IFS= read -r file; do \
+		first_line=$$(LC_ALL=C sed -n '1p' "$$file"); \
+		if [[ "$$first_line" =~ ^\#\!.*[[:space:]/](bash|sh)([[:space:]]|$$) ]]; then \
+			seen=0; \
+			for listed in "$${files[@]}"; do \
+				if [ "$$listed" = "$$file" ]; then seen=1; break; fi; \
+			done; \
+			if [ "$$seen" -eq 0 ]; then files+=("$$file"); fi; \
+		fi; \
+	done < <(git ls-files -- bin hooks); \
+	if [ "$${#files[@]}" -eq 0 ]; then \
+		echo "lint: no shell scripts found"; \
+		exit 0; \
+	fi; \
+	printf 'shellcheck: %s\n' "$${files[@]}"; \
+	shellcheck --severity=warning --exclude=SC2155 "$${files[@]}"

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The details live in reader-specific docs, one level deeper.
 
 ## Project status
 
-- **CI:** Live. gitleaks, history-check, test + lint (ubuntu & macOS), pr-size, and the risk-review gate run on every PR as callers of the family reusable workflows (pinned `ci-v1`); the badge above is painted by the test-lint workflow.
+- **CI:** Live. gitleaks, history-check, test + lint (ubuntu & macOS; lint = shellcheck over the shell scripts), pr-size, and the risk-review gate run on every PR as callers of the family reusable workflows (pinned `ci-v1`); the badge above is painted by the test-lint workflow.
 - **Verified environments:** macOS (local + CI runner) | Linux (CI runner, ubuntu-latest).
 - **Maturity:** v0.2.0 shipped the sixth piece, `wt-snapshot`. Interfaces may still move.
 - **Known limits:** Safety guards are fail-open by design: a broken guard never blocks the agent. The project is macOS-first; the Linux/GNU tar path of `wt-snapshot` is exercised by CI.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,43 +1,79 @@
 #!/usr/bin/env bash
 #
-# Batch test runner: discovers and runs every tests/test_*.sh suite,
-# including tests/test_npm_installer.sh.
+# Batch test runner: discovers and runs every tests/test_*.sh suite.
 #
 # - No fail-fast: every declared suite is executed even if an earlier one
 #   fails.
 # - Streams each suite's stdout/stderr live (no swallowing).
-# - Prints a PASS/FAIL verdict per suite and a declared/executed summary.
-# - Exits non-zero if any suite fails, or if zero suites are discovered.
+# - status 77 produces SKIP; status 0 produces PASS; other statuses produce
+#   FAIL.
+# - The EXIT trap emits the summary for every closed runner outcome.
 
 set -euo pipefail
 
-ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-TESTS_DIR="${ROOT}/tests"
-
+# DECLARED is the number of discovered suites. An interrupted run intentionally
+# reports declared > executed + skipped, exposing a suite that was dropped.
 DECLARED=0
 EXECUTED=0
+SKIP_COUNT=0
 PASS_COUNT=0
 FAIL_COUNT=0
 FAILED_NAMES=""
 
+# shellcheck disable=SC2329 # The EXIT trap invokes finish indirectly.
+finish() {
+  rc=$?
+  trap - EXIT
+  printf 'suites: declared=%s executed=%s skipped=%s\n' "${DECLARED}" "${EXECUTED}" "${SKIP_COUNT}"
+  printf 'passed: %s, failed: %s\n' "${PASS_COUNT}" "${FAIL_COUNT}"
+  if [ -n "${FAILED_NAMES}" ]; then
+    printf 'failed suites:%s\n' "${FAILED_NAMES}"
+  fi
+
+  if [ "${FAIL_COUNT}" -ne 0 ]; then
+    exit 1
+  fi
+
+  case "${rc}" in
+    0|1|2|127) exit "${rc}" ;;
+    *) exit 1 ;;
+  esac
+}
+
+trap finish EXIT
+trap 'exit 1' HUP INT TERM
+
+if [ "$#" -ne 0 ]; then
+  printf 'usage: tests/run.sh\n' >&2
+  exit 2
+fi
+
+if ! command -v bash >/dev/null 2>&1; then
+  printf 'missing-dep: bash\n' >&2
+  exit 127
+fi
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TESTS_DIR="${ROOT}/tests"
+
 # Discover suites: tests/test_*.sh, in glob expansion order. Uses a plain glob
 # (bash 3.2 safe; no mapfile / associative arrays).
-SUITES=()
 for suite in "${TESTS_DIR}"/test_*.sh; do
   if [ -e "${suite}" ] || [ -L "${suite}" ]; then
-    SUITES+=("${suite}")
+    DECLARED=$((DECLARED + 1))
   fi
 done
 
-DECLARED=${#SUITES[@]}
-
 if [ "${DECLARED}" -eq 0 ]; then
   echo "FAIL: no test suites discovered under ${TESTS_DIR}/test_*.sh" >&2
-  echo "declared: 0, executed: 0, passed: 0, failed: 0"
   exit 1
 fi
 
-for suite in "${SUITES[@]}"; do
+for suite in "${TESTS_DIR}"/test_*.sh; do
+  if [ ! -e "${suite}" ] && [ ! -L "${suite}" ]; then
+    continue
+  fi
+
   name=$(basename "${suite}")
   echo "==> running ${name}"
 
@@ -48,25 +84,20 @@ for suite in "${SUITES[@]}"; do
     status=$?
   fi
 
-  EXECUTED=$((EXECUTED + 1))
-
-  if [ "${status}" -eq 0 ]; then
+  if [ "${status}" -eq 77 ]; then
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    echo "SKIP ${name}"
+  elif [ "${status}" -eq 0 ]; then
+    EXECUTED=$((EXECUTED + 1))
     PASS_COUNT=$((PASS_COUNT + 1))
     echo "PASS ${name}"
   else
-    FAIL_COUNT=$((FAIL_COUNT + 1))
     FAILED_NAMES="${FAILED_NAMES} ${name}"
+    EXECUTED=$((EXECUTED + 1))
+    FAIL_COUNT=$((FAIL_COUNT + 1))
     echo "FAIL ${name} (exit ${status})"
   fi
 done
-
-echo ""
-echo "declared: ${DECLARED}, executed: ${EXECUTED}"
-echo "passed: ${PASS_COUNT}, failed: ${FAIL_COUNT}"
-
-if [ -n "${FAILED_NAMES}" ]; then
-  echo "failed suites:${FAILED_NAMES}"
-fi
 
 if [ "${FAIL_COUNT}" -gt 0 ]; then
   exit 1

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -56,24 +56,23 @@ fi
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 TESTS_DIR="${ROOT}/tests"
 
-# Discover suites: tests/test_*.sh, in glob expansion order. Uses a plain glob
+# Discover suites once, in glob expansion order. Uses a plain glob
 # (bash 3.2 safe; no mapfile / associative arrays).
+SUITES=()
 for suite in "${TESTS_DIR}"/test_*.sh; do
   if [ -e "${suite}" ] || [ -L "${suite}" ]; then
-    DECLARED=$((DECLARED + 1))
+    SUITES+=("${suite}")
   fi
 done
+
+DECLARED=${#SUITES[@]}
 
 if [ "${DECLARED}" -eq 0 ]; then
   echo "FAIL: no test suites discovered under ${TESTS_DIR}/test_*.sh" >&2
   exit 1
 fi
 
-for suite in "${TESTS_DIR}"/test_*.sh; do
-  if [ ! -e "${suite}" ] && [ ! -L "${suite}" ]; then
-    continue
-  fi
-
+for suite in "${SUITES[@]}"; do
   name=$(basename "${suite}")
   echo "==> running ${name}"
 


### PR DESCRIPTION
Closes the runner half of #38 (real lint + T-6 summary line). The CI half (`require_suite_reconciliation: true` in `.github/workflows/test-lint.yml`) stays open for the H-E lane, which owns `.github/workflows/` this cycle.

## What changed

- **`Makefile`** — `make lint` is a real gate: `shellcheck --severity=warning --exclude=SC2155` over git-tracked shell scripts (`*.sh` plus shebang-detected scripts under `bin/` and `hooks/`). Prints the checked file list. Fail-closed on every degenerate path: no `shellcheck` → `missing-dep: shellcheck` (127); no `git` → `missing-dep: git` (127); `git ls-files` failing → exit 1; zero scripts discovered → exit 1. SC2155 is a documented temporary carve-out (12 pre-existing findings in `tests/test_safety_hooks.sh`, left to the #52 lane).
- **`tests/run.sh`** — emits `suites: declared=N executed=M skipped=K` from live tallies. Suites are globbed once into an array; `declared` is that count, so an interrupted run shows `declared > executed + skipped` on purpose. Suite exit 77 = `SKIP`; EXIT trap prints the summary on any termination; positional args → exit 2; exit set {0,1,2,127}.
- **`README.md`** — one sentence in "Project status → CI" now says lint = shellcheck.

## Completion record (L1-7)

**Candidate commit:** `67239d3` (superseding record, L1-8) = reviewed candidate `8e906a0` + one merge commit bringing in `origin/main` (`7fee823`, after PR #57 / #52 landed). The merge's only manual resolution is the README "Project status → CI" bullet, where both edits were kept (lint = shellcheck, and the test-lint `@v0.23.0` pin note). No code changed in the merge; re-verified locally on `67239d3`: `make lint` → 13 files, exit 0; `/bin/bash tests/run.sh` → `suites: declared=8 executed=8 skipped=0`, exit 0. The `@v0.23.0` reusable carries the same reconciliation regex and `make lint` step as `ci-v1` (checked in family-dev-handbook at tag v0.23.0). Seat verdicts below were given on `8e906a0`; the code diff vs main is byte-identical.
**Size:** S/M · **Files declared (WIP on #38):** `Makefile`, `tests/run.sh`, `README.md` · `git diff --stat origin/main...67239d3` = exactly those 3 files. Nothing under `.github/`; `tests/test_safety_hooks.sh` untouched (all three seats confirmed the boundary independently).
**Writer:** Codex GPT-5.6 Sol (`--profile sol`) + two terra deltas · **Design / brief / inspection:** Alpha (Claude Code, Fable 5.1) · **Review seats (loom-seats, size M):** GLM 5.3 / Kimi K3 / Grok 4.6 — different models from the writer (L1-3). Alpha is not counted as a vote.

### Done when → result

| # | Done-when item | Result | Evidence (local, 2026-09-04, macOS `/bin/bash` 3.2.57 + shellcheck 0.11.0; re-run on 8e906a0) |
|---|---|---|---|
| 1 | Real linter wired into `make lint`, fails on a seeded violation once | **PASS** | `make lint` → 13 `shellcheck:` lines (`bin/lg`, `bin/wt-snapshot`, `hooks/scratch-persist.sh`, `hooks/validate-subagent-brief.sh`, `tests/run.sh`, 8× `tests/test_*.sh`; `bin/recall` correctly absent), exit 0. Seeded `tests/zz_seed.sh` with `cd /tmp` → `SC2164 (warning) ... make: *** [lint] Error 1`. `PATH=/usr/bin:/bin make lint` → `missing-dep: shellcheck` / `Error 127`. PATH with make+sed+shellcheck but no git → `missing-dep: git` / `Error 127`. Non-repo copy → `lint: git ls-files failed` / `Error 1`. Repo with no shell scripts → `lint: no shell scripts discovered — refusing to pass an empty lint (fail-closed)` / `Error 1`. CI ubuntu lint job ran the same 13-file pass (green). |
| 2a | `tests/run.sh` emits the T-6 line | **PASS** | `/bin/bash tests/run.sh` → `suites: declared=8 executed=8 skipped=0`, exit 0. SKIP (77) + FAIL (3) fixtures → `SKIP test_zz_skipme.sh`, `FAIL test_zz_fail.sh (exit 3)`, `suites: declared=10 executed=9 skipped=1`, exit 1. Interrupted run (fixture TERMs the runner before any suite finishes) → `suites: declared=9 executed=0 skipped=0`, exit 1 — mismatch visible, as T-6 intends. Zero suites (copy of run.sh in an empty `tests/`, bash 3.2 `set -u`) → FAIL message + `suites: declared=0 executed=0 skipped=0`, exit 1, no empty-array crash. `bash tests/run.sh x` → `usage: tests/run.sh`, exit 2. CI ubuntu test job on this branch: `suites: declared=8 executed=8 skipped=0` and `suite reconciliation OK: declared=8 executed=8 skipped=0 max_skip_percent=20` (gate still at `require_suite_reconciliation: false`, so this is a dry pass). |
| 2b | `.github/workflows/test-lint.yml` sets `require_suite_reconciliation: true` + one green run | **N/A (deferred to the H-E lane)** | `.github/workflows/` is owned by the H-E lane this cycle; this lane was scoped to Makefile / tests/run.sh / README.md. The CI job already prints `reconciliation OK` on this branch, so the flip is a one-line follow-up with no runner work left. #38 stays open until it lands. |

### Review seats (blind, private clones, read-only)

| Seat | Round 1 on d00a3d6 | Round 2 on 8e906a0 (cumulative) |
|---|---|---|
| Kimi K3 | **NO-GO** — MAJOR: `git ls-files` status swallowed by process substitution + empty list → `lint: no shell scripts found` exit 0 (reproduced with git off PATH) | **GO-with-nits** — MAJOR RESOLVED on all 3 paths (no git → 127; ls-files fails → 1; empty → 1). Residual MINORs by design (below). |
| GLM 5.3 | **GO-with-nits** — MINOR: same swallow path (reproduced via non-repo copy); NIT: double glob in run.sh | **GO** — MINOR RESOLVED; double-glob RESOLVED (suite that creates a new `test_*.sh` mid-run is no longer picked up: `declared=9 executed=9`). |
| Grok 4.6 | **GO-with-nits** — MINOR: same swallow path (reproduced with a failing git stub) | **GO-with-nits** — MINOR RESOLVED; NITs unchanged (below). |

Three seats converged independently on the same defect (lint passing on empty discovery). Fixed in `8e906a0`. **Blocking findings after round 2: 0.**

Residual nits, accepted with reasons (no code change):
- **`make` exits 2 while the recipe exits 127/1** (all seats) — GNU make convention; the family lint step is `set -euo pipefail; make lint` and keys on non-zero + the `missing-dep:` message, never on 127 at the process level.
- **`--exclude=SC2155` is repo-wide, not file-scoped** (Grok) — scoping it would need a second shellcheck invocation, reintroducing the two-pass shape round 1 removed. The carve-out is temporary and documented in the Makefile; it goes away with #52.
- **Interrupted run breaks `declared = executed + skipped`** (Kimi/Grok) — intentional and documented in the run.sh header; T-6 defines that mismatch as the red signal for a dropped suite.
- **SIGPIPE (`| head -2`) exits 141 and loses the summary** (Kimi) — not reachable in CI (logs fully consumed); the closed exit set describes the runner's own exits.
- **`--severity=warning` lets info-level findings (e.g. SC2086) through** (GLM) — by design; the gate contract is warning+.

### CI (head 67239d3; identical results were observed on 8e906a0)

gitleaks ✅ · history-check ✅ · pr-size ✅ · repo-state ✅ · test-lint/lint ✅ · test-lint/test ✅ · test-lint/test-macos ✅ · watch ✅ · **risk-review-gate ❌ by design** — `Makefile` and `tests/run.sh` are declared high-risk paths; the gate turns green when a roster owner applies `risk-reviewed` on this head SHA.

### Release

**release:** `N/A` — ③ CI・開発環境の配線のみ（`make lint` / `tests/run.sh` are dev-loop tooling; the npm package ships `bin/`, `kit/`, `README.md`, `LICENSE` only, and the one README sentence changes no instruction a user follows）.
**previous release:** v0.3.3 (2026-08-26) — tag and GitHub Release both exist → 履行済み.

Refs #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
