### PR TITLE
ci: require suite reconciliation in the test-lint caller (#38 Done-when 2b)

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -13,6 +13,9 @@ jobs:
     permissions: {contents: read}
     with:
       run_macos: true
+      # context-kit#38: tests/run.sh emits `suites: declared=N executed=M skipped=K`; make the
+      # reusable's suite-count check a real gate (max_skip_percent stays at the reusable default).
+      require_suite_reconciliation: true
       # context-kit#52: GitHub's ubuntu image does not ship `attr`, so the Linux xattr
       # security cases (xattr-metadata-leak-is-scanned-raw / xattr-metadata-is-excluded-without-scanner)
       # would loudly SKIP. Install it so they execute. macOS has `xattr` built in.


### PR DESCRIPTION
Closes the CI half of #38 (Done-when 2b). One-line flip: `require_suite_reconciliation: true` in the test-lint caller, plus a two-line comment. `max_skip_percent` stays at the reusable's default (20).

Context: PR #58 made `tests/run.sh` emit `suites: declared=N executed=M skipped=K`, and the `@v0.23.0` reusable already printed `suite reconciliation OK: declared=8 executed=8 skipped=0` on main as a dry pass (gate at `false` → notice only). This PR turns that check into a real gate: a missing or mismatched line now fails `test-lint/test`.

## 完了記録 (Completion record)

**candidate SHA:** `aab3ba9` (= PR head at review time; unchanged since)
**implementer:** Alpha (Claude Code, Fable 5.1) — direct 3-line YAML edit (no Codex round: config-only)
**reviewer:** GLM 5.3 / Opus 5 / Kimi K3 (loom-seats `--size S` → `glm-5.3 / opus-5 / kimi-k3`, quorum 3/3; requested = actual for all three, recorded in each seat file)
**identity check:** 別モデル — GLM (Zhipu), Kimi (Moonshot), Opus (Anthropic) are all different models from the implementer's Fable 5.1. Opus and Fable share the Claude lineage → correlated-seats exception record below (L1-10).
**CI:** green — run https://github.com/caty-ai/context-kit/actions/runs/33885225778 on head `aab3ba9`: `test-lint / lint` ✅ · `test-lint / test` ✅ · `test-lint / test-macos` ✅ · gitleaks ✅ · history-check ✅ · pr-size ✅ · repo-state ✅ · external-input-caller ✅ · **`risk-review-gate` ❌ by design** — `.github/workflows/` is a declared high-risk path; turns green when a roster owner applies `risk-reviewed` on this head SHA.
**release:** N/A — ③ CI・開発環境の配線のみ（caller workflow input; nothing in the npm `files` set or user-facing behaviour changes）
**previous release:** v0.3.3 (2026-08-26) — tag and GitHub Release both exist → 履行済み

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| #38 2b: `.github/workflows/test-lint.yml` sets `require_suite_reconciliation: true`, one green run URL | **PASS** | Diff: `+ require_suite_reconciliation: true` under `with:` (`git diff origin/main...aab3ba9` → 1 file, +3). Green run on this head, 2026-09-04: https://github.com/caty-ai/context-kit/actions/runs/33885225778 (`headSha=aab3ba9…`). `test-lint / test` job log (job 101063243888) inline: `require_suite_reconciliation: true` (inputs echo) → `suites: declared=8 executed=8 skipped=0` (make test) → `suite reconciliation OK: declared=8 executed=8 skipped=0 max_skip_percent=20` (reconciliation step, exit 0). Per Opus's note, the SHA + inputs-echo line is what proves the gate ran armed, since the OK line prints identically for `true`/`false`. |
| #38 1 and 2a | N/A (already PASS in PR #58 / main `2cce049`) | Not in this lane's scope; recorded on #38. |

### 宣言 vs 実 diff（L0-6）

`git diff --stat origin/main...aab3ba9`: `.github/workflows/test-lint.yml | 3 +++` — 1 file changed, 3 insertions(+).
宣言ファイル集合（WIP on #38: `.github/workflows/test-lint.yml`）との差分: なし。`@v0.23.0` pin, `run_macos`, `pre_test_setup_ubuntu` byte-identical (all three seats confirmed).

### Review seats (blind, private clones, read-only, round 1 on aab3ba9)

| Seat | requested → actual | Verdict | Findings |
|---|---|---|---|
| GLM 5.3 | glm-5.3 → glm-5.3 | **GO-with-nits** | MINOR: reconciliation enforced on ubuntu `test` only (reusable has no step in `test-macos`) — upstream, not fixable in the caller. NIT: skip cap at 8 suites = 1 skip passes / 2 red. NIT: checks API truncates the step name at `#`. F1–F5 all PASS; independently re-fetched the run and log line. |
| Opus 5 | opus-5 → claude-opus-5 | **GO** | MINOR: same macOS coverage gap. MINOR: gate's discriminating power is narrower than it reads (skipped structurally 0; per-case SKIPs inside a suite invisible). MINOR: evidence must cite head SHA, not just the OK line. NIT: pin-drift caveat now covers this input too — consider naming both inputs in the existing `@v0.23.0` comment. |
| Kimi K3 | kimi-k3 → kimi (Kimi Code CLI) | **GO** | MINOR: same macOS coverage gap. NIT: `risk-review-gate` red until labelled. F1–F5 PASS; verified the job log via `gh api` shows `REQUIRE_RECONCILIATION: true` + OK line. |

**Blocking findings: 0.** All three seats converged independently on the one MINOR (macOS job is not reconciled by the reusable). Accepted without code change, with reasons:
- **macOS not gated** (all seats) — reusable-side design at `@v0.23.0`; the caller cannot add the step. `tests/run.sh` emits the identical line on macOS (live `test-macos` log: `suites: declared=8 executed=8 skipped=0`). Noted on #38 as a possible upstream follow-up (handbook), not a blocker for enabling the Linux gate.
- **Narrow discriminating power** (Opus) — accurate; what the flip buys today is "summary line missing → red" and "executed=0 → red". That is the T-6 contract; per-case SKIP visibility is a different (suite-internal) instrument.
- **Evidence framing** (Opus) — adopted in the table above (SHA + inputs echo + OK line).
- **Extend the pin comment to name both inputs** (Opus NIT) — not applied, to keep the reviewed SHA unchanged; the existing comment already says an undeclared input only warns, which covers this input generically.

### Correlated-seats exception record (L1-10, six fields)

- **scope:** this PR (#60) only — Opus 5 as a review seat while the implementer is Alpha (Fable 5.1)
- **pair:** opus-5 ↔ fable-5.1 (both Claude lineage)
- **reason:** loom-seats size-S deterministic panel (Opus 5 is the current rotation head per the 2026-09-04 owner decision, alpha-loom#139); the two other seats (GLM, Kimi) are off-lineage; the change is a 3-line config flip with a self-verifying CI run
- **approved_by:** 翔さん (owner) — pending; applying `risk-reviewed` on this PR is taken as approval of this record as well (please say so if not)
- **date:** 2026-09-04
- **writer 条件:** applies only because the writer is Alpha for a config-only edit; for Codex-written code the loom-seats writer note (codex-sol panel) applies instead

Refs #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
