### PR TITLE
lint: drop the SC2155 carve-out (#59)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ SHELL := /bin/bash
 test:
 	bash tests/run.sh
 
-# The SC2155 exclusion covers 12 pre-existing findings in `tests/test_safety_hooks.sh`.
-# #38 leaves that file untouched because #52 may edit it; remove the exclusion once it is clean.
 lint:
 	@if ! command -v shellcheck >/dev/null 2>&1; then \
 		echo "missing-dep: shellcheck" >&2; \
@@ -41,4 +39,4 @@ lint:
 		exit 1; \
 	fi; \
 	printf 'shellcheck: %s\n' "$${files[@]}"; \
-	shellcheck --severity=warning --exclude=SC2155 "$${files[@]}"
+	shellcheck --severity=warning "$${files[@]}"

--- a/tests/test_safety_hooks.sh
+++ b/tests/test_safety_hooks.sh
@@ -283,13 +283,20 @@ case_private_allow_bypass_and_fail_open() {
 
 case_api_pattern_families() {
   local case_name="api-key-provider-patterns-block"
-  local anthropic="sk-ant-$(repeat_char 24 x)"
-  local openai="sk-$(repeat_char 40 x)"
-  local google="AIza$(repeat_char 35 x)"
-  local aws="AKIA$(repeat_char 16 X)"
-  local gitlab="glpat-$(repeat_char 24 x)"
-  local github="ghp_$(repeat_char 40 x)"
-  local slack="xoxb-$(repeat_char 12 x)"
+  local anthropic
+  anthropic="sk-ant-$(repeat_char 24 x)"
+  local openai
+  openai="sk-$(repeat_char 40 x)"
+  local google
+  google="AIza$(repeat_char 35 x)"
+  local aws
+  aws="AKIA$(repeat_char 16 X)"
+  local gitlab
+  gitlab="glpat-$(repeat_char 24 x)"
+  local github
+  github="ghp_$(repeat_char 40 x)"
+  local slack
+  slack="xoxb-$(repeat_char 12 x)"
   local entry
   local label
   local token
@@ -317,7 +324,8 @@ case_api_pattern_families() {
 
 case_api_tool_surfaces() {
   local case_name="api-key-write-edit-and-nontarget-surfaces"
-  local token="sk-$(repeat_char 40 x)"
+  local token
+  token="sk-$(repeat_char 40 x)"
 
   run_api "$(payload_for Write "${token}" '/tmp/example.txt')"
   if [ "${RUN_STATUS}" != "2" ]; then
@@ -341,7 +349,8 @@ case_api_tool_surfaces() {
 
 case_api_allow_bypass_exclusion_and_fail_open() {
   local case_name="api-key-allow-bypass-exclusion-and-fail-open"
-  local token="sk-$(repeat_char 40 x)"
+  local token
+  token="sk-$(repeat_char 40 x)"
   local provider_env="provider.env"
 
   run_api "$(payload_for Bash 'printf safe-value')"
@@ -397,7 +406,8 @@ case_api_allow_bypass_exclusion_and_fail_open() {
 case_api_evidence_permissions_and_notice() {
   local case_name="api-key-evidence-is-redacted-mode-0600"
   local evidence_dir="${TMP_DIR}/evidence"
-  local token="sk-$(repeat_char 40 x)"
+  local token
+  token="sk-$(repeat_char 40 x)"
   local evidence_file
 
   mkdir -p "${evidence_dir}"
@@ -421,7 +431,8 @@ case_api_evidence_permissions_and_notice() {
 case_api_default_root_is_0700() {
   local case_name="api-key-default-scratch-root-is-0700"
   local fake_home="${TMP_DIR}/home"
-  local token="sk-$(repeat_char 40 x)"
+  local token
+  token="sk-$(repeat_char 40 x)"
   local payload
   local default_dir="${fake_home}/.claude/scratch/test-agent/memory"
 
@@ -445,7 +456,8 @@ case_api_relative_scratch_is_not_cwd_relative() {
   local fake_home="${TMP_DIR}/relative-home"
   local temp_cwd="${TMP_DIR}/relative-cwd"
   local expected_dir="${fake_home}/.claude/scratch/test-agent/memory/relscratch"
-  local token="sk-$(repeat_char 40 x)"
+  local token
+  token="sk-$(repeat_char 40 x)"
   local payload
   local evidence_file
 


### PR DESCRIPTION
Closes #59. Drops the temporary `--exclude=SC2155` carve-out that PR #58 had to carry: the 12 `local x="$(...)"` sites in `tests/test_safety_hooks.sh` are split into `local x; x="$(...)"`, and the Makefile `lint` target runs plain `shellcheck --severity=warning` (the #38/#52 comment is removed). No other rule, severity, or discovery change.

One semantic note (raised by all three seats as a NIT, accepted): the file runs under `set -euo pipefail`, so a non-zero exit from `repeat_char` (a python3 heredoc) now aborts the suite loudly instead of continuing with an empty token. That is exactly what SC2155 exists to restore; python3 is already an unconditional dependency of earlier cases, and `trap cleanup EXIT` still fires.

## 完了記録 (Completion record)

**candidate SHA:** `d1cdc5d` (= PR head at review time; unchanged since; single commit directly on `f2fc10e` = origin/main)
**implementer:** Codex GPT-5.6 Sol (`--profile sol`, sitter-run, `--sandbox workspace-write`); commit by Alpha (the sandbox cannot write the worktree index lock)
**design / brief / inspection:** Alpha (Claude Code, Fable 5.1) — not counted as a vote
**reviewer:** GLM 5.3 / Opus 5 / Kimi K3 (loom-seats `--size S` → `glm-5.3 / opus-5 / kimi-k3`, quorum 3/3; requested = actual recorded in each seat file)
**identity check:** 別モデル — writer is Codex (OpenAI); all three seats are different vendors (Zhipu / Anthropic / Moonshot). Opus is not same-lineage with the writer, so no correlated-seats record is needed for this PR (loom-seats writer note: codex-sol panel).
**CI:** green — run https://github.com/caty-ai/context-kit/actions/runs/33885610036 on head `d1cdc5d`: `test-lint / lint` ✅ (13 `shellcheck:` lines, 0 findings) · `test-lint / test` ✅ · `test-lint / test-macos` ✅ · gitleaks ✅ · history-check ✅ · pr-size ✅ · repo-state ✅ · external-input-caller ✅ · **`risk-review-gate` ❌ by design** — `Makefile` is a declared high-risk path; turns green when a roster owner applies `risk-reviewed` on this head SHA.
**release:** N/A — ③ CI・開発環境の配線のみ（`make lint` and a test file are dev-loop tooling, not in the npm `files` set）
**previous release:** v0.3.3 (2026-08-26) — tag and GitHub Release both exist → 履行済み

### Done when → 結果

| Done when 項目 | 結果 | 証拠（local: macOS `/bin/bash` 3.2.57 + shellcheck 0.11.0, 2026-09-04, on d1cdc5d） |
|---|---|---|
| 1. All 12 SC2155 sites fixed by declare/assign split, no behaviour change | **PASS** | `git diff --numstat origin/main...d1cdc5d -- tests/test_safety_hooks.sh` → `24 12` (12 removed `local x="…"`, 24 added lines). Two seats (GLM, Opus) independently extracted removed vs added RHS and found **identical 12-element multisets** — names, values, quoting byte-for-byte. `shellcheck --severity=warning tests/test_safety_hooks.sh` → no output, exit 0. Only semantic delta is the `set -e` fail-loud note above. |
| 2. Makefile lint runs without `--exclude=SC2155`; #38/#52 comment removed | **PASS** | `git diff origin/main...d1cdc5d -- Makefile` = `-2` comment lines + `-shellcheck --severity=warning --exclude=SC2155 "$${files[@]}"` / `+shellcheck --severity=warning "$${files[@]}"`. Discovery and all four fail-closed branches byte-identical (three seats confirmed). |
| 3. `make lint` = 0 findings; seeded warning still fails it | **PASS** | `make lint` → 13 `shellcheck:` lines, exit 0, no findings (local + CI lint job). Seeded in a private clone (Alpha): `tests/zz_seed.sh` with `cd /tmp` → `SC2164 (warning) … make: *** [lint] Error 1` (exit 2); then `local x=$(date)` → `SC2155 (warning) … make: *** [lint] Error 1` — the carve-out is gone and a new SC2155 now fails the gate. Opus seeded `local z="$(date)"` into `tests/run.sh` → same SC2155 red, then restored (`git status --porcelain` empty). Opus also ran `shellcheck --severity=style --include=SC2155` over all 13 discovered files → exit 0: the exclude was covering no other site. |
| 4. `make test` green 8/8/0; `test_safety_hooks.sh` pass count unchanged vs main | **PASS** | `bash tests/test_safety_hooks.sh` on main (`f2fc10e`): `SUMMARY pass=11 fail=0 skip=0`; on `d1cdc5d`: `SUMMARY pass=11 fail=0 skip=0` (Alpha, Codex, and all three seats; GLM reproduced main from a pristine `git archive`). Full `make test` in the worktree: `suites: declared=8 executed=8 skipped=0` / `passed: 8, failed: 0`, exit 0. |
| 5. CI test-lint/lint and test-lint/test green | **PASS** | Run 33885610036 on `d1cdc5d`: lint job log ends with 13 `shellcheck:` lines and success; test job log: `suites: declared=8 executed=8 skipped=0` → `suite reconciliation OK: declared=8 executed=8 skipped=0 max_skip_percent=20` (dry pass on this branch; the gate flip itself is PR #60). `test-macos`: `suites: declared=8 executed=8 skipped=0`. |

### 宣言 vs 実 diff（L0-6）

`git diff --stat origin/main...d1cdc5d`: `Makefile | 4 +---`, `tests/test_safety_hooks.sh | 36 ++++++++++++++++++++++++------------` — 2 files changed, 25 insertions(+), 15 deletions(-).
宣言ファイル集合（WIP on #59: `Makefile`, `tests/test_safety_hooks.sh`）との差分: なし. (Codex's hook appended nothing to `.gitignore` in this run; worktree clean after commit.)

### Review seats (blind, private clones, read-only, round 1 on d1cdc5d)

| Seat | requested → actual | Verdict | Findings |
|---|---|---|---|
| GLM 5.3 | glm-5.3 → glm-5.3 | **GO** | MINOR: `risk-review-gate` red on the PR — the intended human checkpoint for `Makefile`, not a diff defect. NIT: `set -e` failure-mode change (accepted, see top). NIT: discovery-scope caveat — files outside `make lint`'s discovery set are not linted (pre-existing #38 scope). F1–F5 PASS with multiset proof, pristine-main comparison, seeded `local x="$(false)"` red. (Seat wrote "12-file set" while listing 11 + 2 = 13; arithmetic slip, evidence itself matches the 13-line CI/local output.) |
| Opus 5 | opus-5 → claude-opus-5 | **GO** | NIT: same `set -e` note ("no behaviour change" slightly overstated — fail-loud is strictly better). NIT: CI (Done-when 5) not asserted from the clone. F1–F5 PASS; seeded SC2155 into `tests/run.sh` → red, restored; `--include=SC2155` sweep clean; `git revert --no-commit d1cdc5d` → empty diff vs main. |
| Kimi K3 | kimi-k3 → kimi (Kimi Code CLI) | **GO** | NIT: same `set -e` note (python3 is already an unconditional dependency of earlier cases, so it cannot newly fail here). F1–F5 PASS; 7 + 5 split sites confirmed; seeded `local x="$(date)"` → SC2155 red. |

**Blocking findings: 0.** Three seats converged independently on one NIT (the `set -e` semantics), which is the intended effect of the rule and is now stated in the PR summary. No delta round needed.

Refs #59, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
